### PR TITLE
Makes GTest fully optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 3.10)
 project(usgscsm VERSION 0.0.1 DESCRIPTION "usgscsm library")
-
+  
+include(GoogleTest)
 include(cmake/gtest.cmake)
 include(GNUInstallDirs)
-include(GoogleTest)
 
 set(CMAKE_CXX_STANDARD 11)
 
@@ -44,12 +44,8 @@ target_include_directories(usgscsm
                            ${CSM_INCLUDE_DIR}
 )
 
-# Setup for GoogleTest
-find_package (Threads)
-
 target_link_libraries(usgscsm
-                      ${CSM_LIBRARY}
-                      gtest ${CMAKE_THREAD_LIBS_INIT})
+                      ${CSM_LIBRARY})
 
 if(WIN32)
   install(TARGETS usgscsm RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR})
@@ -62,6 +58,12 @@ install(DIRECTORY ${USGSCSM_INCLUDE_DIRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR
 # Optional build or link against CSM
 option (BUILD_TESTS "Build tests" ON)
 if(BUILD_TESTS)
+  
+  # Setup for GoogleTest
+  find_package (Threads)
+
+  target_link_libraries(usgscsm
+                        gtest ${CMAKE_THREAD_LIBS_INIT})
   include(CTest)
   enable_testing()
   add_subdirectory(tests)


### PR DESCRIPTION
This PR is trying to make GTest fully optional to fix build issues on the conda-forge feedstock of CSM where GTest is not being installed and the GTest repo is not being cloned.