### PR TITLE
Further isolates gtest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(usgscsm VERSION 0.0.1 DESCRIPTION "usgscsm library")
 
-include(GoogleTest)
-include(cmake/gtest.cmake)
 include(GNUInstallDirs)
 
 set(CMAKE_CXX_STANDARD 11)
@@ -58,6 +56,9 @@ install(DIRECTORY ${USGSCSM_INCLUDE_DIRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR
 # Optional build or link against CSM
 option (BUILD_TESTS "Build tests" ON)
 if(BUILD_TESTS)
+
+  include(GoogleTest)
+  include(cmake/gtest.cmake)
 
   # Setup for GoogleTest
   find_package (Threads)


### PR DESCRIPTION
So, I did not isolate GTest enough. I just tested this on my Mac and:

```
TEST END: /Users/jlaura/miniconda3/conda-bld/osx-64/usgscsm-1.1.1-0.tar.bz2
Renaming work directory,  /<me>/miniconda3/conda-bld/usgscsm_1551115360642/work  to  /<me>/miniconda3/conda-bld/usgscsm_1551115360642/work_moved_usgscsm-1.1.1-0_osx-64_main_build_loop
# Automatic uploading is disabled
# If you want to upload package(s) to anaconda.org later, type:

anaconda upload /Users/jlaura/miniconda3/conda-bld/osx-64/usgscsm-1.1.1-0.tar.bz2

# To have conda build upload to anaconda.org automatically, use
# $ conda config --set anaconda_upload yes

anaconda_upload is not set.  Not uploading wheels: []
```