### PR TITLE
only add gtest if tests are being built

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 project(usgscsm VERSION 0.0.1 DESCRIPTION "usgscsm library")
 
-include(GoogleTest)
-include(cmake/gtest.cmake)
+
 include(GNUInstallDirs)
 
 set(CMAKE_CXX_STANDARD 11)
@@ -58,7 +57,8 @@ install(DIRECTORY ${USGSCSM_INCLUDE_DIRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR
 # Optional build or link against CSM
 option (BUILD_TESTS "Build tests" ON)
 if(BUILD_TESTS)
-
+  include(GoogleTest)
+  include(cmake/gtest.cmake)
   # Setup for GoogleTest
   find_package (Threads)
 


### PR DESCRIPTION
Without this change, I wasn't able to build usgscsm without gtest. 