### PR TITLE
Added tests to check that the framer logs

### DIFF
--- a/include/usgscsm/UsgsAstroFrameSensorModel.h
+++ b/include/usgscsm/UsgsAstroFrameSensorModel.h
@@ -313,6 +313,7 @@ class UsgsAstroFrameSensorModel : public csm::RasterGM {
         csm::param::Set pSet = csm::param::VALID,
         const GeometricModelList &otherModels = GeometricModelList()) const;
     virtual std::shared_ptr<spdlog::logger> getLogger();
+    virtual void setLogger(std::shared_ptr<spdlog::logger> logger);
 
     static const std::string _SENSOR_MODEL_NAME;
 

--- a/include/usgscsm/UsgsAstroFrameSensorModel.h
+++ b/include/usgscsm/UsgsAstroFrameSensorModel.h
@@ -314,6 +314,15 @@ class UsgsAstroFrameSensorModel : public csm::RasterGM {
         const GeometricModelList &otherModels = GeometricModelList()) const;
     virtual std::shared_ptr<spdlog::logger> getLogger();
     virtual void setLogger(std::shared_ptr<spdlog::logger> logger);
+    double getValue(int index, const std::vector<double> &adjustments) const;
+    void calcRotationMatrix(double m[3][3]) const;
+    void calcRotationMatrix(double m[3][3], const std::vector<double> &adjustments) const;
+
+    void losEllipsoidIntersect (double height,double xc,
+                                double yc, double zc,
+                                double xl, double yl,
+                                double zl,
+                                double& x,double& y, double&  z) const;
 
     static const std::string _SENSOR_MODEL_NAME;
 
@@ -374,16 +383,6 @@ class UsgsAstroFrameSensorModel : public csm::RasterGM {
     static const std::string _STATE_KEYWORD[];
 
     csm::NoCorrelationModel _no_corr_model;
-
-    double getValue(int index,const std::vector<double> &adjustments) const;
-    void calcRotationMatrix(double m[3][3]) const;
-    void calcRotationMatrix(double m[3][3], const std::vector<double> &adjustments) const;
-
-    void losEllipsoidIntersect (double height,double xc,
-                                double yc, double zc,
-                                double xl, double yl,
-                                double zl,
-                                double& x,double& y, double&  z) const;
 
 };
 

--- a/src/UsgsAstroFrameSensorModel.cpp
+++ b/src/UsgsAstroFrameSensorModel.cpp
@@ -1070,6 +1070,8 @@ bool UsgsAstroFrameSensorModel::isParameterShareable(int index) const {
 
 
 csm::SharingCriteria UsgsAstroFrameSensorModel::getParameterSharingCriteria(int index) const {
+   MESSAGE_LOG(this->m_logger, "Checking sharing criteria for parameter {}. "
+               "Sharing is not supported, throwing exception", index);
    // Parameter sharing is not supported for this sensor,
    // all indices are out of range
    throw csm::Error(
@@ -1126,6 +1128,9 @@ int UsgsAstroFrameSensorModel::getNumGeometricCorrectionSwitches() const {
 
 
 std::string UsgsAstroFrameSensorModel::getGeometricCorrectionName(int index) const {
+   MESSAGE_LOG(this->m_logger, "Accessing name of geometric correction switch {}. "
+               "Geometric correction switches are not supported, throwing exception",
+               index);
    // Since there are no geometric corrections, all indices are out of range
    throw csm::Error(
       csm::Error::INDEX_OUT_OF_RANGE,
@@ -1137,6 +1142,10 @@ std::string UsgsAstroFrameSensorModel::getGeometricCorrectionName(int index) con
 void UsgsAstroFrameSensorModel::setGeometricCorrectionSwitch(int index,
                                                       bool value,
                                                       csm::param::Type pType) {
+   MESSAGE_LOG(this->m_logger, "Setting geometric correction switch {} to {} "
+               "with parameter type {}. "
+               "Geometric correction switches are not supported, throwing exception",
+               index, value, pType);
    // Since there are no geometric corrections, all indices are out of range
    throw csm::Error(
       csm::Error::INDEX_OUT_OF_RANGE,
@@ -1146,6 +1155,9 @@ void UsgsAstroFrameSensorModel::setGeometricCorrectionSwitch(int index,
 
 
 bool UsgsAstroFrameSensorModel::getGeometricCorrectionSwitch(int index) const {
+   MESSAGE_LOG(this->m_logger, "Accessing value of geometric correction switch {}. "
+               "Geometric correction switches are not supported, throwing exception",
+               index);
    // Since there are no geometric corrections, all indices are out of range
    throw csm::Error(
       csm::Error::INDEX_OUT_OF_RANGE,

--- a/src/UsgsAstroFrameSensorModel.cpp
+++ b/src/UsgsAstroFrameSensorModel.cpp
@@ -772,7 +772,7 @@ bool UsgsAstroFrameSensorModel::isValidModelState(const std::string& stringState
     }
   }
 
-  if (!missingKeywords.empty()) {
+  if (!missingKeywords.empty() && warnings) {
     std::ostringstream oss;
     std::copy(missingKeywords.begin(), missingKeywords.end(), std::ostream_iterator<std::string>(oss, " "));
     warnings->push_back(csm::Warning(
@@ -784,7 +784,7 @@ bool UsgsAstroFrameSensorModel::isValidModelState(const std::string& stringState
 
   std::string modelName = jsonState.value<std::string>("m_modelName", "");
 
-  if (modelName != _SENSOR_MODEL_NAME) {
+  if (modelName != _SENSOR_MODEL_NAME && warnings) {
     warnings->push_back(csm::Warning(
       csm::Warning::DATA_NOT_AVAILABLE,
       "Incorrect model name in state, expected " + _SENSOR_MODEL_NAME + " but got " + modelName,

--- a/src/UsgsAstroFrameSensorModel.cpp
+++ b/src/UsgsAstroFrameSensorModel.cpp
@@ -1282,3 +1282,7 @@ double UsgsAstroFrameSensorModel::getValue(
 std::shared_ptr<spdlog::logger> UsgsAstroFrameSensorModel::getLogger() {
   return m_logger;
 }
+
+void UsgsAstroFrameSensorModel::setLogger(std::shared_ptr<spdlog::logger> logger) {
+  m_logger = logger;
+}

--- a/tests/Fixtures.h
+++ b/tests/Fixtures.h
@@ -97,6 +97,8 @@ class FrameSensorModelLogging : public ::testing::Test {
             delete sensorModel;
             sensorModel = NULL;
          }
+
+         EXPECT_FALSE(oss.str().empty());
       }
 };
 

--- a/tests/Fixtures.h
+++ b/tests/Fixtures.h
@@ -9,9 +9,12 @@
 
 #include <map>
 #include <sstream>
+#include <string>
 #include <fstream>
 
 #include <gtest/gtest.h>
+
+#include <spdlog/sinks/ostream_sink.h>
 
 using json = nlohmann::json;
 
@@ -52,6 +55,41 @@ class FrameSensorModel : public ::testing::Test {
          sensorModel = dynamic_cast<UsgsAstroFrameSensorModel *>(model);
 
          ASSERT_NE(sensorModel, nullptr);
+      }
+
+      void TearDown() override {
+         if (sensorModel) {
+            delete sensorModel;
+            sensorModel = NULL;
+         }
+      }
+};
+
+class FrameSensorModelLogging : public ::testing::Test {
+   protected:
+      csm::Isd isd;
+      UsgsAstroFrameSensorModel *sensorModel;
+      std::ostringstream oss;
+
+      void SetUp() override {
+         sensorModel = NULL;
+
+         isd.setFilename("data/simpleFramerISD.img");
+         UsgsAstroPlugin frameCameraPlugin;
+
+         csm::Model *model = frameCameraPlugin.constructModelFromISD(
+               isd,
+               "USGS_ASTRO_FRAME_SENSOR_MODEL");
+         sensorModel = dynamic_cast<UsgsAstroFrameSensorModel *>(model);
+
+         ASSERT_NE(sensorModel, nullptr);
+
+         auto ostream_sink = std::make_shared<spdlog::sinks::ostream_sink_mt> (oss);
+         // We need a unique ID for the sensor model so that we don't have
+         // logger name collisions. Use the sensor model's memory addresss.
+         std::uintptr_t sensorId = reinterpret_cast<std::uintptr_t>(sensorModel);
+         auto logger = std::make_shared<spdlog::logger>(std::to_string(sensorId), ostream_sink);
+         sensorModel->setLogger(logger);
       }
 
       void TearDown() override {

--- a/tests/FrameCameraTests.cpp
+++ b/tests/FrameCameraTests.cpp
@@ -666,3 +666,13 @@ TEST_F(FrameSensorModelLogging, GetGeometricCorrectionSwitch) {
     // Just testing logging, so do nothing, it should still log
   }
 }
+
+TEST_F(FrameSensorModelLogging, GetIlluminationDirection) {
+  csm::EcefCoord groundPt(10.0, 0.0, 0.0);
+  sensorModel->getIlluminationDirection(groundPt);
+}
+
+TEST_F(FrameSensorModelLogging, ComputeGroundPartials) {
+  csm::EcefCoord groundPt(10.0, 0.0, 0.0);
+  sensorModel->computeGroundPartials(groundPt);
+}

--- a/tests/FrameCameraTests.cpp
+++ b/tests/FrameCameraTests.cpp
@@ -211,7 +211,6 @@ TEST_F(FrameSensorModel, X1e9_SlightlyOffCenter) {
    sensorModel = NULL;
 }
 
-
 // Angle rotations:
 TEST_F(FrameSensorModel, Rotation_omegaPi_Center) {
    sensorModel->setParameterValue(3, 1.0);
@@ -235,7 +234,6 @@ TEST_F(FrameSensorModel, Rotation_omegaPi_Center) {
    sensorModel = NULL;
 }
 
-
 TEST_F(FrameSensorModel, Rotation_NPole_Center) {
   sensorModel->setParameterValue(3, 0.0);
   sensorModel->setParameterValue(4, -1.0);
@@ -258,7 +256,6 @@ TEST_F(FrameSensorModel, Rotation_NPole_Center) {
   sensorModel = NULL;
 }
 
-
 TEST_F(FrameSensorModel, Rotation_SPole_Center) {
    sensorModel->setParameterValue(3, 0.0); // phi
    sensorModel->setParameterValue(0, 0.0); // X
@@ -275,7 +272,6 @@ TEST_F(FrameSensorModel, Rotation_SPole_Center) {
    delete sensorModel;
    sensorModel = NULL;
 }
-
 
 // Ellipsoid axis tests:
 TEST_F(FrameStateTest, SemiMajorAxis100x_Center) {
@@ -295,7 +291,6 @@ TEST_F(FrameStateTest, SemiMajorAxis100x_Center) {
   sensorModel = NULL;
 }
 
-
 TEST_F(FrameStateTest, SemiMajorAxis10x_SlightlyOffCenter) {
   std::string key = "m_majorAxis";
   double newValue = 100.0;
@@ -313,7 +308,6 @@ TEST_F(FrameStateTest, SemiMajorAxis10x_SlightlyOffCenter) {
   delete sensorModel;
   sensorModel = NULL;
 }
-
 
 // The following test is for the scenario where the semi_minor_axis is actually larger
 // than the semi_major_axis:
@@ -333,7 +327,6 @@ TEST_F(FrameStateTest, SemiMinorAxis10x_SlightlyOffCenter) {
   sensorModel = NULL;
 }
 
-
 TEST_F(FrameStateTest, SampleSumming) {
   std::string key = "m_detectorSampleSumming";
   double newValue = 2.0;
@@ -349,7 +342,6 @@ TEST_F(FrameStateTest, SampleSumming) {
   delete sensorModel;
   sensorModel = NULL;
 }
-
 
 TEST_F(FrameStateTest, LineSumming) {
   std::string key = "m_detectorLineSumming";
@@ -367,7 +359,6 @@ TEST_F(FrameStateTest, LineSumming) {
   sensorModel = NULL;
 }
 
-
 TEST_F(FrameStateTest, StartSample) {
   std::string key = "m_startingDetectorSample";
   double newValue = 5.0;
@@ -384,7 +375,6 @@ TEST_F(FrameStateTest, StartSample) {
   sensorModel = NULL;
 }
 
-
 TEST_F(FrameStateTest, StartLine) {
   std::string key = "m_startingDetectorLine";
   double newValue = 5.0;
@@ -399,4 +389,17 @@ TEST_F(FrameStateTest, StartLine) {
 
   delete sensorModel;
   sensorModel = NULL;
+}
+
+TEST_F(FrameSensorModelLogging, GroundToImage) {
+  csm::EcefCoord groundPt(10.0, 0.0, 0.0);
+  sensorModel->groundToImage(groundPt);
+  EXPECT_FALSE(oss.str().empty());
+}
+
+TEST_F(FrameSensorModelLogging, GroundToImageAdjustments) {
+  csm::EcefCoord groundPt(10.0, 0.0, 0.0);
+  std::vector<double> adjustments(7, 0.0);
+  sensorModel->groundToImage(groundPt, adjustments);
+  EXPECT_FALSE(oss.str().empty());
 }

--- a/tests/FrameCameraTests.cpp
+++ b/tests/FrameCameraTests.cpp
@@ -9,6 +9,10 @@
 using json = nlohmann::json;
 // NOTE: The imagePt format is (Lines,Samples)
 
+// ****************************************************************************
+//   Basic sensor model tests
+// ****************************************************************************
+
 TEST_F(FrameSensorModel, State) {
    std::string modelState = sensorModel->getModelState();
    EXPECT_NO_THROW(
@@ -87,6 +91,10 @@ TEST_F(FrameSensorModel, Inversion) {
    EXPECT_DOUBLE_EQ(imagePt1.samp, imagePt2.samp);
 }
 
+// ****************************************************************************
+//   Orbital sensor model tests
+// ****************************************************************************
+
 TEST_F(OrbitalFrameSensorModel, Center) {
    csm::ImageCoord imagePt(8.0, 8.0);
    csm::EcefCoord groundPt = sensorModel->imageToGround(imagePt, 0.0);
@@ -110,6 +118,9 @@ TEST_F(OrbitalFrameSensorModel, GroundPartials) {
    EXPECT_DOUBLE_EQ(partials[5], 0.0);
 }
 
+// ****************************************************************************
+//   Modified sensor model tests
+// ****************************************************************************
 
 // Focal Length Tests:
 TEST_F(FrameStateTest, FL500_OffBody4) {
@@ -128,7 +139,6 @@ TEST_F(FrameStateTest, FL500_OffBody4) {
   sensorModel = NULL;
 }
 
-
 TEST_F(FrameStateTest, FL500_OffBody3) {
   std::string key = "m_focalLength";
   double newValue = 500.0;
@@ -144,7 +154,6 @@ TEST_F(FrameStateTest, FL500_OffBody3) {
   delete sensorModel;
   sensorModel = NULL;
 }
-
 
 TEST_F(FrameStateTest, FL500_Center) {
   std::string key = "m_focalLength";
@@ -162,7 +171,6 @@ TEST_F(FrameStateTest, FL500_Center) {
   sensorModel = NULL;
 }
 
-
 TEST_F(FrameStateTest, FL500_SlightlyOffCenter) {
   std::string key = "m_focalLength";
   double newValue = 500.0;
@@ -177,100 +185,6 @@ TEST_F(FrameStateTest, FL500_SlightlyOffCenter) {
 
   delete sensorModel;
   sensorModel = NULL;
-}
-
-// Observer x position:
-TEST_F(FrameSensorModel, X10_SlightlyOffCenter) {
-   double newValue = 10.0;
-   sensorModel->setParameterValue(0, newValue); // X
-
-   ASSERT_NE(sensorModel, nullptr);
-   csm::ImageCoord imagePt(7.5, 6.5);
-   csm::EcefCoord groundPt = sensorModel->imageToGround(imagePt, 0.0);
-   EXPECT_NEAR(groundPt.x, 10.0, 1e-8);
-   EXPECT_NEAR(groundPt.y, 0.0, 1e-8);
-   EXPECT_NEAR(groundPt.z, 0.0, 1e-8);
-
-   delete sensorModel;
-   sensorModel = NULL;
-}
-
-TEST_F(FrameSensorModel, X1e9_SlightlyOffCenter) {
-   double newValue = 1000000000.0;
-   sensorModel->setParameterValue(0, newValue); // X
-
-   ASSERT_NE(sensorModel, nullptr);
-   csm::ImageCoord imagePt(7.5, 6.5);
-   csm::EcefCoord groundPt = sensorModel->imageToGround(imagePt, 0.0);
-   // Note: In the following, the tolerance was increased due to the very large distance being tested (~6.68 AU).
-   EXPECT_NEAR(groundPt.x, 3.99998400e+03, 1e-4);
-   EXPECT_NEAR(groundPt.y, 0.0, 1e-4);
-   EXPECT_NEAR(groundPt.z, 1.99999200e+06, 1e-4);
-
-   delete sensorModel;
-   sensorModel = NULL;
-}
-
-// Angle rotations:
-TEST_F(FrameSensorModel, Rotation_omegaPi_Center) {
-   sensorModel->setParameterValue(3, 1.0);
-   sensorModel->setParameterValue(4, 1.0);
-   sensorModel->setParameterValue(5, 1.0);
-
-   sensorModel->setParameterValue(6, 1.0);
-
-   sensorModel->setParameterValue(0, 1000.0); // X
-   sensorModel->setParameterValue(1, 0.0); // Y
-   sensorModel->setParameterValue(2, 0.0); // Z
-
-   ASSERT_NE(sensorModel, nullptr);
-   csm::ImageCoord imagePt(7.5, 7.5);
-   csm::EcefCoord groundPt = sensorModel->imageToGround(imagePt, 0.0);
-   EXPECT_NEAR(groundPt.x, -10.0, 1e-8);
-   EXPECT_NEAR(groundPt.y, 0.0, 1e-8);
-   EXPECT_NEAR(groundPt.z, 0.0, 1e-8);
-
-   delete sensorModel;
-   sensorModel = NULL;
-}
-
-TEST_F(FrameSensorModel, Rotation_NPole_Center) {
-  sensorModel->setParameterValue(3, 0.0);
-  sensorModel->setParameterValue(4, -1.0);
-  sensorModel->setParameterValue(5, 0.0);
-
-  sensorModel->setParameterValue(6, 0.0);
-
-  sensorModel->setParameterValue(0, 0.0); // X
-  sensorModel->setParameterValue(1, 0.0); // Y
-  sensorModel->setParameterValue(2, 1000.0); // Z
-
-  ASSERT_NE(sensorModel, nullptr);
-  csm::ImageCoord imagePt(7.5, 7.5);
-  csm::EcefCoord groundPt = sensorModel->imageToGround(imagePt, 0.0);
-  EXPECT_NEAR(groundPt.x, 0.0, 1e-8);
-  EXPECT_NEAR(groundPt.y, 0.0, 1e-8);
-  EXPECT_NEAR(groundPt.z, 10.0, 1e-8);
-
-  delete sensorModel;
-  sensorModel = NULL;
-}
-
-TEST_F(FrameSensorModel, Rotation_SPole_Center) {
-   sensorModel->setParameterValue(3, 0.0); // phi
-   sensorModel->setParameterValue(0, 0.0); // X
-   sensorModel->setParameterValue(1, 0.0); // Y
-   sensorModel->setParameterValue(2, -1000.0); // Z
-
-   ASSERT_NE(sensorModel, nullptr);
-   csm::ImageCoord imagePt(7.5, 7.5);
-   csm::EcefCoord groundPt = sensorModel->imageToGround(imagePt, 0.0);
-   EXPECT_NEAR(groundPt.x, 0.0, 1e-8);
-   EXPECT_NEAR(groundPt.y, 0.0, 1e-8);
-   EXPECT_NEAR(groundPt.z, -10.0, 1e-8);
-
-   delete sensorModel;
-   sensorModel = NULL;
 }
 
 // Ellipsoid axis tests:
@@ -390,6 +304,108 @@ TEST_F(FrameStateTest, StartLine) {
   delete sensorModel;
   sensorModel = NULL;
 }
+
+// ****************************************************************************
+//   Adjustable parameter tests
+// ****************************************************************************
+
+// Observer x position:
+TEST_F(FrameSensorModel, X10_SlightlyOffCenter) {
+   double newValue = 10.0;
+   sensorModel->setParameterValue(0, newValue); // X
+
+   ASSERT_NE(sensorModel, nullptr);
+   csm::ImageCoord imagePt(7.5, 6.5);
+   csm::EcefCoord groundPt = sensorModel->imageToGround(imagePt, 0.0);
+   EXPECT_NEAR(groundPt.x, 10.0, 1e-8);
+   EXPECT_NEAR(groundPt.y, 0.0, 1e-8);
+   EXPECT_NEAR(groundPt.z, 0.0, 1e-8);
+
+   delete sensorModel;
+   sensorModel = NULL;
+}
+
+TEST_F(FrameSensorModel, X1e9_SlightlyOffCenter) {
+   double newValue = 1000000000.0;
+   sensorModel->setParameterValue(0, newValue); // X
+
+   ASSERT_NE(sensorModel, nullptr);
+   csm::ImageCoord imagePt(7.5, 6.5);
+   csm::EcefCoord groundPt = sensorModel->imageToGround(imagePt, 0.0);
+   // Note: In the following, the tolerance was increased due to the very large distance being tested (~6.68 AU).
+   EXPECT_NEAR(groundPt.x, 3.99998400e+03, 1e-4);
+   EXPECT_NEAR(groundPt.y, 0.0, 1e-4);
+   EXPECT_NEAR(groundPt.z, 1.99999200e+06, 1e-4);
+
+   delete sensorModel;
+   sensorModel = NULL;
+}
+
+// Angle rotations:
+TEST_F(FrameSensorModel, Rotation_omegaPi_Center) {
+   sensorModel->setParameterValue(3, 1.0);
+   sensorModel->setParameterValue(4, 1.0);
+   sensorModel->setParameterValue(5, 1.0);
+
+   sensorModel->setParameterValue(6, 1.0);
+
+   sensorModel->setParameterValue(0, 1000.0); // X
+   sensorModel->setParameterValue(1, 0.0); // Y
+   sensorModel->setParameterValue(2, 0.0); // Z
+
+   ASSERT_NE(sensorModel, nullptr);
+   csm::ImageCoord imagePt(7.5, 7.5);
+   csm::EcefCoord groundPt = sensorModel->imageToGround(imagePt, 0.0);
+   EXPECT_NEAR(groundPt.x, -10.0, 1e-8);
+   EXPECT_NEAR(groundPt.y, 0.0, 1e-8);
+   EXPECT_NEAR(groundPt.z, 0.0, 1e-8);
+
+   delete sensorModel;
+   sensorModel = NULL;
+}
+
+TEST_F(FrameSensorModel, Rotation_NPole_Center) {
+  sensorModel->setParameterValue(3, 0.0);
+  sensorModel->setParameterValue(4, -1.0);
+  sensorModel->setParameterValue(5, 0.0);
+
+  sensorModel->setParameterValue(6, 0.0);
+
+  sensorModel->setParameterValue(0, 0.0); // X
+  sensorModel->setParameterValue(1, 0.0); // Y
+  sensorModel->setParameterValue(2, 1000.0); // Z
+
+  ASSERT_NE(sensorModel, nullptr);
+  csm::ImageCoord imagePt(7.5, 7.5);
+  csm::EcefCoord groundPt = sensorModel->imageToGround(imagePt, 0.0);
+  EXPECT_NEAR(groundPt.x, 0.0, 1e-8);
+  EXPECT_NEAR(groundPt.y, 0.0, 1e-8);
+  EXPECT_NEAR(groundPt.z, 10.0, 1e-8);
+
+  delete sensorModel;
+  sensorModel = NULL;
+}
+
+TEST_F(FrameSensorModel, Rotation_SPole_Center) {
+   sensorModel->setParameterValue(3, 0.0); // phi
+   sensorModel->setParameterValue(0, 0.0); // X
+   sensorModel->setParameterValue(1, 0.0); // Y
+   sensorModel->setParameterValue(2, -1000.0); // Z
+
+   ASSERT_NE(sensorModel, nullptr);
+   csm::ImageCoord imagePt(7.5, 7.5);
+   csm::EcefCoord groundPt = sensorModel->imageToGround(imagePt, 0.0);
+   EXPECT_NEAR(groundPt.x, 0.0, 1e-8);
+   EXPECT_NEAR(groundPt.y, 0.0, 1e-8);
+   EXPECT_NEAR(groundPt.z, -10.0, 1e-8);
+
+   delete sensorModel;
+   sensorModel = NULL;
+}
+
+// ****************************************************************************
+//   Logging tests
+// ****************************************************************************
 
 TEST_F(FrameSensorModelLogging, GroundToImage) {
   csm::EcefCoord groundPt(10.0, 0.0, 0.0);
@@ -675,4 +691,53 @@ TEST_F(FrameSensorModelLogging, GetIlluminationDirection) {
 TEST_F(FrameSensorModelLogging, ComputeGroundPartials) {
   csm::EcefCoord groundPt(10.0, 0.0, 0.0);
   sensorModel->computeGroundPartials(groundPt);
+}
+
+TEST_F(FrameSensorModelLogging, IsValidModelState) {
+  sensorModel->isValidModelState("{\"test_key\" : \"test_string\"}", nullptr);
+}
+
+TEST_F(FrameSensorModelLogging, IsValidIsd) {
+  sensorModel->isValidIsd("{\"test_key\" : \"test_string\"}", nullptr);
+}
+
+TEST_F(FrameSensorModelLogging, ConstructStateFromIsd) {
+  try {
+    sensorModel->constructStateFromIsd("{\"test_key\" : \"test_string\"}", nullptr);
+  }
+  catch (...) {
+    // Just testing logging, so do nothing, it should still log
+  }
+}
+
+TEST_F(FrameSensorModelLogging, GetValue) {
+  std::vector<double> adjustments(7, 0.0);
+  sensorModel->getValue(0, adjustments);
+}
+
+TEST_F(FrameSensorModelLogging, CalcRotationMatrix) {
+  double m[3][3];
+  sensorModel->calcRotationMatrix(m);
+}
+
+TEST_F(FrameSensorModelLogging, CalcRotationMatrixAdjusted) {
+  std::vector<double> adjustments(7, 0.0);
+  double m[3][3];
+  sensorModel->calcRotationMatrix(m, adjustments);
+}
+
+TEST_F(FrameSensorModelLogging, losEllipsoidIntersect) {
+  double height, xc, yc, zc, xl, yl, zl, x, y, z;
+  height = 0.0;
+  xc = 1000;
+  yc = 0.0;
+  zc = 0.0;
+  xl = -1.0;
+  yl = 0.0;
+  zl = 0.0;
+  sensorModel->losEllipsoidIntersect(
+        height,
+        xc, yc, zc,
+        xl, yl, zl,
+        x, y, z);
 }

--- a/tests/FrameCameraTests.cpp
+++ b/tests/FrameCameraTests.cpp
@@ -394,12 +394,275 @@ TEST_F(FrameStateTest, StartLine) {
 TEST_F(FrameSensorModelLogging, GroundToImage) {
   csm::EcefCoord groundPt(10.0, 0.0, 0.0);
   sensorModel->groundToImage(groundPt);
-  EXPECT_FALSE(oss.str().empty());
 }
 
 TEST_F(FrameSensorModelLogging, GroundToImageAdjustments) {
   csm::EcefCoord groundPt(10.0, 0.0, 0.0);
   std::vector<double> adjustments(7, 0.0);
   sensorModel->groundToImage(groundPt, adjustments);
-  EXPECT_FALSE(oss.str().empty());
+}
+
+TEST_F(FrameSensorModelLogging, GroundToImageCovariance) {
+  csm::EcefCoordCovar groundPt(10.0, 0.0, 0.0,
+                               1.0, 0.0, 0.0,
+                                    1.0, 0.0,
+                                         1.0);
+  sensorModel->groundToImage(groundPt);
+}
+
+TEST_F(FrameSensorModelLogging, ImageToGround) {
+  csm::ImageCoord imagePt(7.5, 7.5);
+  sensorModel->imageToGround(imagePt, 0.0, 1.0);
+}
+
+TEST_F(FrameSensorModelLogging, ImageToGroundCovariance) {
+  csm::ImageCoordCovar imagePt(7.5, 7.5,
+                               1.0, 0.0,
+                                    1.0);
+  sensorModel->imageToGround(imagePt, 0.0);
+}
+
+TEST_F(FrameSensorModelLogging, ImageToProximateImagingLocus) {
+  csm::ImageCoord imagePt(7.5, 7.5);
+  csm::EcefCoord groundPt(10.0, 0.0, 0.0);
+  sensorModel->imageToProximateImagingLocus(imagePt, groundPt);
+}
+
+TEST_F(FrameSensorModelLogging, ImageToRemoteImagingLocus) {
+  csm::ImageCoord imagePt(7.5, 7.5);
+  sensorModel->imageToRemoteImagingLocus(imagePt);
+}
+
+TEST_F(FrameSensorModelLogging, GetImageStart) {
+  sensorModel->getImageStart();
+}
+
+TEST_F(FrameSensorModelLogging, GetImageSize) {
+  sensorModel->getImageSize();
+}
+
+TEST_F(FrameSensorModelLogging, GetValidImageRange) {
+  sensorModel->getValidImageRange();
+}
+
+TEST_F(FrameSensorModelLogging, GetValidHeightRange) {
+  sensorModel->getValidHeightRange();
+}
+
+TEST_F(FrameSensorModelLogging, GetImageTime) {
+  csm::ImageCoord imagePt(7.5, 7.5);
+  sensorModel->getImageTime(imagePt);
+}
+
+TEST_F(FrameSensorModelLogging, GetSensorPositionPixel) {
+  csm::ImageCoord imagePt(7.5, 7.5);
+  sensorModel->getSensorPosition(imagePt);
+}
+
+TEST_F(FrameSensorModelLogging, GetSensorPositionTime) {
+  csm::ImageCoord imagePt(7.5, 7.5);
+  double time = sensorModel->getImageTime(imagePt);
+  // Dump the constents of the stream because getModelState wrote to it
+  oss.str("");
+  oss.clear();
+  sensorModel->getSensorPosition(time);
+}
+
+TEST_F(FrameSensorModelLogging, GetSensorVelocityPixel) {
+  csm::ImageCoord imagePt(7.5, 7.5);
+  sensorModel->getSensorVelocity(imagePt);
+}
+
+TEST_F(FrameSensorModelLogging, GetSensorVelocityTime) {
+  csm::ImageCoord imagePt(7.5, 7.5);
+  double time = sensorModel->getImageTime(imagePt);
+  // Dump the constents of the stream because getModelState wrote to it
+  oss.str("");
+  oss.clear();
+  sensorModel->getSensorVelocity(time);
+}
+
+TEST_F(FrameSensorModelLogging, ComputeSensorPartialsGround) {
+  csm::EcefCoord groundPt(10.0, 0.0, 0.0);
+  sensorModel->computeSensorPartials(0, groundPt);
+}
+
+TEST_F(FrameSensorModelLogging, ComputeSensorPartialsBoth) {
+  csm::ImageCoord imagePt(7.5, 7.5);
+  csm::EcefCoord groundPt(10.0, 0.0, 0.0);
+  sensorModel->computeSensorPartials(0, imagePt, groundPt);
+}
+
+TEST_F(FrameSensorModelLogging, ComputeAllSensorPartialsGround) {
+  csm::EcefCoord groundPt(10.0, 0.0, 0.0);
+  sensorModel->computeAllSensorPartials(groundPt);
+}
+
+TEST_F(FrameSensorModelLogging, ComputeAllSensorPartialsBoth) {
+  csm::ImageCoord imagePt(7.5, 7.5);
+  csm::EcefCoord groundPt(10.0, 0.0, 0.0);
+  sensorModel->computeAllSensorPartials(imagePt, groundPt);
+}
+
+TEST_F(FrameSensorModelLogging, GetCorrelationModel) {
+  sensorModel->getCorrelationModel();
+}
+
+TEST_F(FrameSensorModelLogging, GetUnmodeledCrossCovariance) {
+  csm::ImageCoord imagePt1(7.5, 7.5);
+  csm::ImageCoord imagePt2(8.5, 8.5);
+  sensorModel->getUnmodeledCrossCovariance(imagePt1, imagePt2);
+}
+
+TEST_F(FrameSensorModelLogging, GetVersion) {
+  sensorModel->getVersion();
+}
+
+TEST_F(FrameSensorModelLogging, GetModelName) {
+  sensorModel->getModelName();
+}
+
+TEST_F(FrameSensorModelLogging, GetPedigree) {
+  sensorModel->getPedigree();
+}
+
+TEST_F(FrameSensorModelLogging, GetImageIdentifier) {
+  sensorModel->getImageIdentifier();
+}
+
+TEST_F(FrameSensorModelLogging, SetImageIdentifier) {
+  sensorModel->setImageIdentifier("logging_ID");
+}
+
+TEST_F(FrameSensorModelLogging, GetSensorIdentifier) {
+  sensorModel->getSensorIdentifier();
+}
+
+TEST_F(FrameSensorModelLogging, GetPlatformIdentifier) {
+  sensorModel->getPlatformIdentifier();
+}
+
+TEST_F(FrameSensorModelLogging, GetCollectionIdentifier) {
+  sensorModel->getCollectionIdentifier();
+}
+
+TEST_F(FrameSensorModelLogging, GetTrajectoryIdentifier) {
+  sensorModel->getTrajectoryIdentifier();
+}
+
+TEST_F(FrameSensorModelLogging, GetSensorType) {
+  sensorModel->getSensorType();
+}
+
+TEST_F(FrameSensorModelLogging, GetSensorMode) {
+  sensorModel->getSensorMode();
+}
+
+TEST_F(FrameSensorModelLogging, GetReferenceDateAndTime) {
+  sensorModel->getReferenceDateAndTime();
+}
+
+TEST_F(FrameSensorModelLogging, GetModelState) {
+  sensorModel->getModelState();
+}
+
+TEST_F(FrameSensorModelLogging, replaceModelState) {
+  std::string state = sensorModel->getModelState();
+  // Dump the constents of the stream because getModelState wrote to it
+  oss.str("");
+  oss.clear();
+  sensorModel->replaceModelState(state);
+}
+
+TEST_F(FrameSensorModelLogging, GetReferencePoint) {
+  sensorModel->getReferencePoint();
+}
+
+TEST_F(FrameSensorModelLogging, SetReferencePoint) {
+  csm::EcefCoord groundPt(10.0, 0.0, 0.0);
+  sensorModel->setReferencePoint(groundPt);
+}
+
+TEST_F(FrameSensorModelLogging, GetNumParameters) {
+  sensorModel->getNumParameters();
+}
+
+TEST_F(FrameSensorModelLogging, GetParameterName) {
+  sensorModel->getParameterName(0);
+}
+
+TEST_F(FrameSensorModelLogging, GetParameterUnits) {
+  sensorModel->getParameterUnits(0);
+}
+
+TEST_F(FrameSensorModelLogging, HasShareableParameters) {
+  sensorModel->hasShareableParameters();
+}
+
+TEST_F(FrameSensorModelLogging, IsParameterShareable) {
+  sensorModel->isParameterShareable(0);
+}
+
+TEST_F(FrameSensorModelLogging, GetParameterSharingCriteria) {
+  try {
+    sensorModel->getParameterSharingCriteria(0);
+  }
+  catch (...) {
+    // Just testing logging, so do nothing, it should still log
+  }
+}
+
+TEST_F(FrameSensorModelLogging, GetParameterValue) {
+  sensorModel->getParameterValue(0);
+}
+
+TEST_F(FrameSensorModelLogging, SetParameterValue) {
+  sensorModel->setParameterValue(0, 10);
+}
+
+TEST_F(FrameSensorModelLogging, GetParameterType) {
+  sensorModel->getParameterType(0);
+}
+
+TEST_F(FrameSensorModelLogging, SetParameterType) {
+  sensorModel->setParameterType(0, csm::param::REAL);
+}
+
+TEST_F(FrameSensorModelLogging, GetParameterCovariance) {
+  sensorModel->getParameterCovariance(0, 0);
+}
+
+TEST_F(FrameSensorModelLogging, SetParameterCovariance) {
+  sensorModel->setParameterCovariance(0, 0, 1);
+}
+
+TEST_F(FrameSensorModelLogging, GetNumGeometricCorrectionSwitches) {
+  sensorModel->getNumGeometricCorrectionSwitches();
+}
+
+TEST_F(FrameSensorModelLogging, GetGeometricCorrectionName) {
+  try {
+    sensorModel->getGeometricCorrectionName(0);
+  }
+  catch (...) {
+    // Just testing logging, so do nothing, it should still log
+  }
+}
+
+TEST_F(FrameSensorModelLogging, SetGeometricCorrectionSwitch) {
+  try {
+    sensorModel->setGeometricCorrectionSwitch(0, true, csm::param::REAL);
+  }
+  catch (...) {
+    // Just testing logging, so do nothing, it should still log
+  }
+}
+
+TEST_F(FrameSensorModelLogging, GetGeometricCorrectionSwitch) {
+  try {
+    sensorModel->getGeometricCorrectionSwitch(0);
+  }
+  catch (...) {
+    // Just testing logging, so do nothing, it should still log
+  }
 }


### PR DESCRIPTION
Once logging is in the line scan, we should do this for the linescan.

I also added logging to the methods in the framer that throw an exception because they are not supported.

There is one method that is not tested, `getCrossCovarianceMatrix`, because I am unsure how we are supposed to call it.

