### PR TITLE
Updated Kaguya LISM distortion model

### DIFF
--- a/include/usgscsm/Distortion.h
+++ b/include/usgscsm/Distortion.h
@@ -9,7 +9,6 @@
 enum DistortionType {
   RADIAL,
   TRANSVERSE,
-  KAGUYATC,
   KAGUYALISM,
   DAWNFC,
   LROLROCNAC

--- a/include/usgscsm/Distortion.h
+++ b/include/usgscsm/Distortion.h
@@ -10,6 +10,7 @@ enum DistortionType {
   RADIAL,
   TRANSVERSE,
   KAGUYATC,
+  KAGUYALISM,
   DAWNFC,
   LROLROCNAC
 };

--- a/src/Distortion.cpp
+++ b/src/Distortion.cpp
@@ -1,4 +1,6 @@
 #include "Distortion.h"
+
+#include <Error.h>
 #include <string>
 
 void distortionJacobian(double x, double y, double *jacobian,
@@ -186,7 +188,10 @@ void removeDistortion(double dx, double dy, double &ux, double &uy,
 
       // Coeffs should be [boresightX,x0,x1,x2,x3,boresightY,y0,y1,y2,y3]
       if (opticalDistCoeffs.size() != 10) {
-        throw "Distortion coefficients for Kaguya LISM must be of size 10, got: " +  std::to_string(opticalDistCoeffs.size());
+        csm::Error::ErrorType errorType = csm::Error::INDEX_OUT_OF_RANGE;
+        std::string message = "Distortion coefficients for Kaguya LISM must be of size 10, got: " +  std::to_string(opticalDistCoeffs.size());
+        std::string function = "removeDistortion";
+        throw csm::Error(errorType, message, function);
       }
 
       double boresightX = opticalDistCoeffs[0];
@@ -266,14 +271,20 @@ void removeDistortion(double dx, double dy, double &ux, double &uy,
     case LROLROCNAC: {
 
       if (opticalDistCoeffs.size() != 1) {
-        throw "Distortion coefficients for LRO LROC NAC must be of size 1, current size: " +  std::to_string(opticalDistCoeffs.size());
+        csm::Error::ErrorType errorType = csm::Error::INDEX_OUT_OF_RANGE;
+        std::string message = "Distortion coefficients for LRO LROC NAC must be of size 1, current size: " +  std::to_string(opticalDistCoeffs.size());
+        std::string function = "removeDistortion";
+        throw csm::Error(errorType, message, function);
       }
 
       double dk1 = opticalDistCoeffs[0];
 
       double den = 1 + dk1 * dy * dy;     // r = dy*dy = distance from the focal plane center
       if (den == 0.0) {
-        throw "Unable to remove distortion for LRO LROC NAC. Focal plane position " + std::to_string(dy);
+        csm::Error::ErrorType errorType = csm::Error::ALGORITHM;
+        std::string message = "Unable to remove distortion for LRO LROC NAC. Focal plane position " + std::to_string(dy);
+        std::string function = "removeDistortion";
+        throw csm::Error(errorType, message, function);
       }
 
       ux = dx;
@@ -349,7 +360,10 @@ void applyDistortion(double ux, double uy, double &dx, double &dy,
 
     case KAGUYALISM: {
       if (opticalDistCoeffs.size() != 10) {
-        throw "Distortion coefficients for Kaguya LISM must be of size 10, got: " +  std::to_string(opticalDistCoeffs.size());
+          csm::Error::ErrorType errorType = csm::Error::INDEX_OUT_OF_RANGE;
+          std::string message = "Distortion coefficients for Kaguya LISM must be of size 10, got: " +  std::to_string(opticalDistCoeffs.size());
+          std::string function = "applyDistortion";
+          throw csm::Error(errorType, message, function);
       }
 
       double boresightX = opticalDistCoeffs[0];
@@ -443,7 +457,10 @@ void applyDistortion(double ux, double uy, double &dx, double &dy,
       bool bConverged = false;
 
       if (opticalDistCoeffs.size() != 1) {
-        throw "Distortion coefficients for LRO LROC NAC must be of size 1, current size: " +  std::to_string(opticalDistCoeffs.size());
+        csm::Error::ErrorType errorType = csm::Error::INDEX_OUT_OF_RANGE;
+        std::string message = "Distortion coefficients for LRO LROC NAC must be of size 1, current size: " +  std::to_string(opticalDistCoeffs.size());
+        std::string function = "applyDistortion";
+        throw csm::Error(errorType, message, function);
       }
 
       double dk1 = opticalDistCoeffs[0];

--- a/src/Utilities.cpp
+++ b/src/Utilities.cpp
@@ -768,6 +768,9 @@ DistortionType getDistortionModel(json isd, csm::WarningList *list) {
     else if (distortion.compare("kaguyatc") == 0) {
       return DistortionType::KAGUYATC;
     }
+    else if (distortion.compare("kaguyalism") == 0) {
+      return DistortionType::KAGUYALISM;
+    }
     else if (distortion.compare("dawnfc") == 0) {
       return DistortionType::DAWNFC;
     }
@@ -858,6 +861,33 @@ std::vector<double> getDistortionCoeffs(json isd, csm::WarningList *list) {
             csm::Warning(
               csm::Warning::DATA_NOT_AVAILABLE,
               "Could not parse a set of transverse distortion model coefficients.",
+              "Utilities::getDistortion()"));
+        }
+        coefficients = std::vector<double>(8, 0.0);
+      }
+    }
+    case DistortionType::KAGUYALISM: {
+      try {
+
+        std::vector<double> coefficientsX = isd.at("optical_distortion").at("kaguyalism").at("x").get<std::vector<double>>();
+        std::vector<double> coefficientsY = isd.at("optical_distortion").at("kaguyalism").at("y").get<std::vector<double>>();
+        double boresightX = isd.at("optical_distortion").at("kaguyalism").at("boresight_x").get<double>();
+        double boresightY = isd.at("optical_distortion").at("kaguyalism").at("boresight_y").get<double>();
+
+        coefficientsX.resize(4, 0.0);
+        coefficientsY.resize(4, 0.0);
+        coefficientsX.insert(coefficientsX.begin(), boresightX);
+        coefficientsY.insert(coefficientsY.begin(), boresightY);
+        coefficientsX.insert(coefficientsX.end(), coefficientsY.begin(), coefficientsY.end());
+
+        return coefficientsX;
+      }
+      catch (...) {
+        if (list) {
+          list->push_back(
+            csm::Warning(
+              csm::Warning::DATA_NOT_AVAILABLE,
+              "Could not parse a set of Kaguya LISM distortion model coefficients.",
               "Utilities::getDistortion()"));
         }
         coefficients = std::vector<double>(8, 0.0);

--- a/src/Utilities.cpp
+++ b/src/Utilities.cpp
@@ -765,9 +765,6 @@ DistortionType getDistortionModel(json isd, csm::WarningList *list) {
     else if (distortion.compare("radial") == 0) {
       return DistortionType::RADIAL;
     }
-    else if (distortion.compare("kaguyatc") == 0) {
-      return DistortionType::KAGUYATC;
-    }
     else if (distortion.compare("kaguyalism") == 0) {
       return DistortionType::KAGUYALISM;
     }
@@ -844,28 +841,6 @@ std::vector<double> getDistortionCoeffs(json isd, csm::WarningList *list) {
       }
     }
     break;
-    case DistortionType::KAGUYATC: {
-      try {
-
-        std::vector<double> coefficientsX = isd.at("optical_distortion").at("kaguyatc").at("x").get<std::vector<double>>();
-        coefficientsX.resize(4, 0.0);
-        std::vector<double> coefficientsY = isd.at("optical_distortion").at("kaguyatc").at("y").get<std::vector<double>>();
-        coefficientsY.resize(4, 0.0);
-        coefficientsX.insert(coefficientsX.end(), coefficientsY.begin(), coefficientsY.end());
-
-        return coefficientsX;
-      }
-      catch (...) {
-        if (list) {
-          list->push_back(
-            csm::Warning(
-              csm::Warning::DATA_NOT_AVAILABLE,
-              "Could not parse a set of transverse distortion model coefficients.",
-              "Utilities::getDistortion()"));
-        }
-        coefficients = std::vector<double>(8, 0.0);
-      }
-    }
     case DistortionType::KAGUYALISM: {
       try {
 

--- a/tests/DistortionTests.cpp
+++ b/tests/DistortionTests.cpp
@@ -257,6 +257,65 @@ TEST(KaguyaTc, testZeroCoeffs) {
   ASSERT_DOUBLE_EQ(uy, 1.0);
 }
 
+TEST(KaguyaLism, testRemoveCoeffs) {
+  csm::ImageCoord imagePt(1.0, 1.0);
+
+  double ux, uy;
+  double desiredPrecision = 0.0000001;
+  std::vector<double> distortionCoeffs = {0.5, 1, 2, 3, 4,
+                                          0.5, 1, 2, 3, 4};
+
+  removeDistortion(imagePt.samp, imagePt.line, ux, uy, distortionCoeffs,
+                  DistortionType::KAGUYALISM, desiredPrecision);
+
+  EXPECT_NEAR(ux, 1 + 1 + 2.828427125 + 6 + 11.313708499 + 0.5, 1e-8);
+  EXPECT_NEAR(uy, 1 + 1 + 2.828427125 + 6 + 11.313708499 + 0.5, 1e-8);
+}
+
+
+TEST(KaguyaLism, testCoeffs) {
+  csm::ImageCoord imagePt(1.0, 1.0);
+
+  double ux, uy, dx, dy;
+  double desiredPrecision = 0.0000001;
+  // Coeffs obtained from file TC1W2B0_01_05211N095E3380.img
+  std::vector<double> coeffs = {-0.0725, -0.0009649900000000001, 0.00098441, 8.5773e-06, -3.7438e-06,
+                                0.0214, -0.0013796, 1.3502e-05, 2.7251e-06, -6.193800000000001e-06};
+
+  removeDistortion(imagePt.samp, imagePt.line, ux, uy, coeffs,
+                  DistortionType::KAGUYALISM, desiredPrecision);
+  applyDistortion(ux, uy, dx, dy, coeffs,
+                  DistortionType::KAGUYALISM, desiredPrecision);
+
+
+
+  EXPECT_NEAR(ux, 0.9279337415074662, 1e-6);
+  EXPECT_NEAR(uy, 1.0200274261995939, 1e-5);
+  EXPECT_NEAR(dx, 1.0, 1e-8);
+  EXPECT_NEAR(dy, 1.0, 1e-8);
+}
+
+
+TEST(KaguyaLism, testZeroCoeffs) {
+  csm::ImageCoord imagePt(1.0, 1.0);
+
+  double ux, uy, dx, dy;
+  double desiredPrecision = 0.0000001;
+  std::vector<double> coeffs = {0, 0, 0, 0, 0,
+                                0, 0, 0, 0, 0};
+
+  applyDistortion(imagePt.samp, imagePt.line, dx, dy, coeffs,
+                  DistortionType::KAGUYALISM, desiredPrecision);
+
+  removeDistortion(dx, dy, ux, uy, coeffs,
+                  DistortionType::KAGUYALISM, desiredPrecision);
+
+  ASSERT_DOUBLE_EQ(dx, 1.0);
+  ASSERT_DOUBLE_EQ(dy, 1.0);
+  ASSERT_DOUBLE_EQ(ux, 1.0);
+  ASSERT_DOUBLE_EQ(uy, 1.0);
+}
+
 
 // Test for LRO LROC NAC
 TEST(LroLrocNac, testLastDetectorSample) {
@@ -314,4 +373,3 @@ TEST(LroLrocNac, testZeroCoeffs) {
   ASSERT_DOUBLE_EQ(ux, 0.0);
   ASSERT_DOUBLE_EQ(uy, 0.0);
 }
-

--- a/tests/DistortionTests.cpp
+++ b/tests/DistortionTests.cpp
@@ -199,64 +199,6 @@ TEST(DawnFc, testZeroCoeffs) {
   ASSERT_DOUBLE_EQ(uy, 10.0);
 }
 
-TEST(KaguyaTc, testRemoveCoeffs) {
-  csm::ImageCoord imagePt(1.0, 1.0);
-
-  double ux, uy;
-  double desiredPrecision = 0.0000001;
-  std::vector<double> distortionCoeffs = {1, 2, 3, 4,
-                                          1, 2, 3, 4};
-
-  removeDistortion(imagePt.samp, imagePt.line, ux, uy, distortionCoeffs,
-                  DistortionType::KAGUYATC, desiredPrecision);
-
-  EXPECT_NEAR(ux, 1 + 1 + 2.828427125 + 6 + 11.313708499, 1e-8);
-  EXPECT_NEAR(uy, 1 + 1 + 2.828427125 + 6 + 11.313708499, 1e-8);
-}
-
-
-TEST(KaguyaTc, testCoeffs) {
-  csm::ImageCoord imagePt(1.0, 1.0);
-
-  double ux, uy, dx, dy;
-  double desiredPrecision = 0.0000001;
-  // Coeffs obtained from file TC1W2B0_01_05211N095E3380.img
-  std::vector<double> coeffs = {-0.0009649900000000001, 0.00098441, 8.5773e-06, -3.7438e-06,
-                                -0.0013796, 1.3502e-05, 2.7251e-06, -6.193800000000001e-06};
-
-  applyDistortion(imagePt.samp, imagePt.line, dx, dy, coeffs,
-                  DistortionType::KAGUYATC, desiredPrecision);
-
-  removeDistortion(dx, dy, ux, uy, coeffs,
-                  DistortionType::KAGUYATC, desiredPrecision);
-
-  EXPECT_NEAR(dx, 0.999566, 1e-6);
-  EXPECT_NEAR(dy, 1.00137, 1e-5);
-  EXPECT_NEAR(ux, 1.0, 1e-8);
-  EXPECT_NEAR(uy, 1.0, 1e-8);
-}
-
-
-TEST(KaguyaTc, testZeroCoeffs) {
-  csm::ImageCoord imagePt(1.0, 1.0);
-
-  double ux, uy, dx, dy;
-  double desiredPrecision = 0.0000001;
-  std::vector<double> coeffs = {0, 0, 0, 0,
-                                0, 0, 0, 0};
-
-  applyDistortion(imagePt.samp, imagePt.line, dx, dy, coeffs,
-                  DistortionType::KAGUYATC, desiredPrecision);
-
-  removeDistortion(dx, dy, ux, uy, coeffs,
-                  DistortionType::KAGUYATC, desiredPrecision);
-
-  ASSERT_DOUBLE_EQ(dx, 1.0);
-  ASSERT_DOUBLE_EQ(dy, 1.0);
-  ASSERT_DOUBLE_EQ(ux, 1.0);
-  ASSERT_DOUBLE_EQ(uy, 1.0);
-}
-
 TEST(KaguyaLism, testRemoveCoeffs) {
   csm::ImageCoord imagePt(1.0, 1.0);
 


### PR DESCRIPTION
This is the distortion model used by both the TC and MI, which are part of the LISM.

The only change from the old Kaguya TC distortion model is accounting for the boresight as indicated in the IKs and Hiro's script.

This is going to require a coordinated change in ALE to provide the updated distortion. I thought about keeping it backwards compatible and setting the boresight values to 0, but I don't want to introduce a situation where the code silently falls back to a less correct solution to support old ISDs.