### PR TITLE
Fixed Line Scan test images having lines flipped

### DIFF
--- a/tests/data/constVelocityLineScan.json
+++ b/tests/data/constVelocityLineScan.json
@@ -13,7 +13,7 @@
   "dt_ephemeris": 0.2,
   "t0_quaternion": -0.8,
   "dt_quaternion": 0.2,
-  "focal2pixel_lines": [0.0, 10.0, 0.0],
+  "focal2pixel_lines": [0.0, -10.0, 0.0],
   "focal2pixel_samples": [0.0, 0.0, 10.0],
   "focal_length_model": {
     "focal_length": 50

--- a/tests/data/orbitalLineScan.json
+++ b/tests/data/orbitalLineScan.json
@@ -13,7 +13,7 @@
   "dt_ephemeris": 0.1,
   "t0_quaternion": -0.8,
   "dt_quaternion": 0.1,
-  "focal2pixel_lines": [0.0, 10.0, 0.0],
+  "focal2pixel_lines": [0.0, -10.0, 0.0],
   "focal2pixel_samples": [0.0, 0.0, 10.0],
   "focal_length_model": {
     "focal_length": 50


### PR DESCRIPTION
This caused the test images to sometimes fail when testing imageToGround -> groundToImage. For example, if testing line 2, sample 8 that ground point could fall on line 1 or 2. If the algorithm picks line 1, it should map to ccd line 1 and then back to image line 2. because the ccd lines were flipped, it instead mapped to ccd line -1 and then back to image line 0.