### PR TITLE
Inaccurate Implementation for getReferenceDateAndTime

### DIFF
--- a/src/UsgsAstroFrameSensorModel.cpp
+++ b/src/UsgsAstroFrameSensorModel.cpp
@@ -678,7 +678,20 @@ std::string UsgsAstroFrameSensorModel::getSensorMode() const {
 
 std::string UsgsAstroFrameSensorModel::getReferenceDateAndTime() const {
   MESSAGE_LOG(this->m_logger, "Accessing reference data and time");
-  return "";
+  csm::EcefCoord referencePointGround = UsgsAstroFrameSensorModel::getReferencePoint();
+  csm::ImageCoord referencePointImage = UsgsAstroFrameSensorModel::groundToImage(referencePointGround);
+  double relativeTime = UsgsAstroFrameSensorModel::getImageTime(referencePointImage);
+  time_t ephemTime = m_ephemerisTime + relativeTime;
+  struct tm t = {0};  // Initalize to all 0's
+  t.tm_year = 100;  // This is year-1900, so 100 = 2000
+  t.tm_mday = 1;
+  time_t timeSinceEpoch = mktime(&t);
+  time_t finalTime = ephemTime + timeSinceEpoch;
+  char buffer [16];
+  strftime(buffer, 16, "%Y%m%dT%H%M%S", localtime(&finalTime));
+  buffer[15] = '\0';
+
+  return buffer;
 }
 
 

--- a/src/UsgsAstroFrameSensorModel.cpp
+++ b/src/UsgsAstroFrameSensorModel.cpp
@@ -680,8 +680,7 @@ std::string UsgsAstroFrameSensorModel::getReferenceDateAndTime() const {
   MESSAGE_LOG(this->m_logger, "Accessing reference data and time");
   csm::EcefCoord referencePointGround = UsgsAstroFrameSensorModel::getReferencePoint();
   csm::ImageCoord referencePointImage = UsgsAstroFrameSensorModel::groundToImage(referencePointGround);
-  double relativeTime = UsgsAstroFrameSensorModel::getImageTime(referencePointImage);
-  time_t ephemTime = m_ephemerisTime + relativeTime;
+  time_t ephemTime = UsgsAstroFrameSensorModel::getImageTime(referencePointImage);
   struct tm t = {0};  // Initalize to all 0's
   t.tm_year = 100;  // This is year-1900, so 100 = 2000
   t.tm_mday = 1;
@@ -838,6 +837,7 @@ void UsgsAstroFrameSensorModel::replaceModelState(const std::string& stringState
         m_focalLengthEpsilon = state.at("m_focalLengthEpsilon").get<double>();
         m_nLines = state.at("m_nLines").get<int>();
         m_nSamples = state.at("m_nSamples").get<int>();
+        m_ephemerisTime = state.at("m_ephemerisTime").get<int>();
         m_currentParameterValue = state.at("m_currentParameterValue").get<std::vector<double>>();
         m_ccdCenter = state.at("m_ccdCenter").get<std::vector<double>>();
         m_spacecraftVelocity = state.at("m_spacecraftVelocity").get<std::vector<double>>();

--- a/src/UsgsAstroLsSensorModel.cpp
+++ b/src/UsgsAstroLsSensorModel.cpp
@@ -1283,10 +1283,20 @@ std::string UsgsAstroLsSensorModel::getTrajectoryIdentifier() const
 //***************************************************************************
 std::string UsgsAstroLsSensorModel::getReferenceDateAndTime() const
 {
-    throw csm::Error(
-       csm::Error::UNSUPPORTED_FUNCTION,
-       "Unsupported function",
-       "UsgsAstroLsSensorModel::getReferenceDateAndTime");
+    csm::EcefCoord referencePointGround = UsgsAstroLsSensorModel::getReferencePoint();
+    std::cout << "Ground point is " << referencePointGround.x << " " << referencePointGround.y << " " << referencePointGround.z << '\n';
+    csm::ImageCoord referencePointImage = UsgsAstroLsSensorModel::groundToImage(referencePointGround);
+    std::cout << "Image point is " << referencePointImage.line << " " << referencePointImage.samp << '\n';
+    double relativeTime = UsgsAstroLsSensorModel::getImageTime(referencePointImage);
+    double time = m_centerEphemerisTime + relativeTime;
+    printf("Reference Time is %f8\n", time);
+
+    return "";
+
+    // throw csm::Error(
+    //    csm::Error::UNSUPPORTED_FUNCTION,
+    //    "Unsupported function",
+    //    "UsgsAstroLsSensorModel::getReferenceDateAndTime");
 }
 
 //***************************************************************************
@@ -1314,6 +1324,7 @@ double UsgsAstroLsSensorModel::getImageTime(
       --referenceLineIt;
    }
    size_t referenceIndex = std::distance(m_intTimeLines.begin(), referenceLineIt);
+   std::cout << "getImageTime for image line " << image_pt.line << " is " << time << '\n';
 
    double time = m_intTimeStartTimes[referenceIndex]
       + m_intTimes[referenceIndex] * (lineUSGSFull - m_intTimeLines[referenceIndex]);

--- a/src/UsgsAstroLsSensorModel.cpp
+++ b/src/UsgsAstroLsSensorModel.cpp
@@ -1284,19 +1284,19 @@ std::string UsgsAstroLsSensorModel::getTrajectoryIdentifier() const
 std::string UsgsAstroLsSensorModel::getReferenceDateAndTime() const
 {
     csm::EcefCoord referencePointGround = UsgsAstroLsSensorModel::getReferencePoint();
-    std::cout << "Ground point is " << referencePointGround.x << " " << referencePointGround.y << " " << referencePointGround.z << '\n';
     csm::ImageCoord referencePointImage = UsgsAstroLsSensorModel::groundToImage(referencePointGround);
-    std::cout << "Image point is " << referencePointImage.line << " " << referencePointImage.samp << '\n';
     double relativeTime = UsgsAstroLsSensorModel::getImageTime(referencePointImage);
-    double time = m_centerEphemerisTime + relativeTime;
-    printf("Reference Time is %f8\n", time);
+    time_t ephemTime = m_centerEphemerisTime + relativeTime;
+    struct tm t = {0};  // Initalize to all 0's
+    t.tm_year = 100;  // This is year-1900, so 100 = 2000
+    t.tm_mday = 1;
+    time_t timeSinceEpoch = mktime(&t);
+    time_t finalTime = ephemTime + timeSinceEpoch;
+    char buffer [16];
+    strftime(buffer, 16, "%Y%m%dT%H%M%S", localtime(&finalTime));
+    buffer[15] = '\0';
 
-    return "";
-
-    // throw csm::Error(
-    //    csm::Error::UNSUPPORTED_FUNCTION,
-    //    "Unsupported function",
-    //    "UsgsAstroLsSensorModel::getReferenceDateAndTime");
+    return buffer;
 }
 
 //***************************************************************************
@@ -1324,16 +1324,14 @@ double UsgsAstroLsSensorModel::getImageTime(
       --referenceLineIt;
    }
    size_t referenceIndex = std::distance(m_intTimeLines.begin(), referenceLineIt);
-   std::cout << "getImageTime for image line " << image_pt.line << " is " << time << '\n';
 
    double time = m_intTimeStartTimes[referenceIndex]
       + m_intTimes[referenceIndex] * (lineUSGSFull - m_intTimeLines[referenceIndex]);
 
-  MESSAGE_LOG(m_logger, "getImageTime for image line {} is {}",
-                                image_pt.line, time)
+   MESSAGE_LOG(m_logger, "getImageTime for image line {} is {}",
+                         image_pt.line, time)
 
    return time;
-
 }
 
 //***************************************************************************

--- a/tests/FrameCameraTests.cpp
+++ b/tests/FrameCameraTests.cpp
@@ -755,3 +755,8 @@ TEST_F(FrameSensorModelLogging, losEllipsoidIntersect) {
         xl, yl, zl,
         x, y, z);
 }
+
+TEST_F(OrbitalFrameSensorModel, ReferenceDateTime) {
+  std::string date = sensorModel->getReferenceDateAndTime();
+  EXPECT_EQ(date, "20000101T001640");
+}

--- a/tests/LineScanCameraTests.cpp
+++ b/tests/LineScanCameraTests.cpp
@@ -180,7 +180,6 @@ TEST_F(OrbitalLineScanSensorModel, InversionReallyHigh) {
 }
 
 TEST_F(OrbitalLineScanSensorModel, ReferenceDateTime) {
-  csm::EcefCoord groundPoint = csm::EcefCoord(1e+05, 0, -750);
-  sensorModel->setReferencePoint(groundPoint);
-  sensorModel->getReferenceDateAndTime();
+  std::string date = sensorModel->getReferenceDateAndTime();
+  EXPECT_EQ(date, "20000101T001639");
 }

--- a/tests/LineScanCameraTests.cpp
+++ b/tests/LineScanCameraTests.cpp
@@ -178,3 +178,9 @@ TEST_F(OrbitalLineScanSensorModel, InversionReallyHigh) {
     EXPECT_NEAR(imagePt.samp, imageReprojPt.samp, 0.002);
   }
 }
+
+TEST_F(OrbitalLineScanSensorModel, ReferenceDateTime) {
+  csm::EcefCoord groundPoint = csm::EcefCoord(1e+05, 0, -750);
+  sensorModel->setReferencePoint(groundPoint);
+  sensorModel->getReferenceDateAndTime();
+}


### PR DESCRIPTION
Adds an inaccurate implementation to get the date and time of a given reference point on an image. This method is inaccurate due to the differences in time computation between NAIF and default timing libraries. Mainly, NAIF accounting for leap seconds in it's timing the the differences between epochs (NAIF: January 1st, 2000 C++: Janurary 1st: 1970)

Closes #250 