### PR TITLE
Made ground partial step larger

### DIFF
--- a/src/UsgsAstroLsSensorModel.cpp
+++ b/src/UsgsAstroLsSensorModel.cpp
@@ -1145,7 +1145,7 @@ std::vector<double> UsgsAstroLsSensorModel::computeGroundPartials(
    MESSAGE_LOG(m_logger, "Computing computeGroundPartials for point {}, {}, {}",
                                 ground_pt.x, ground_pt.y, ground_pt.z)
 
-   double GND_DELTA = m_gsd;
+   double GND_DELTA = 3 * m_gsd;
    // Partial of line, sample wrt X, Y, Z
    double x = ground_pt.x;
    double y = ground_pt.y;

--- a/tests/LineScanCameraTests.cpp
+++ b/tests/LineScanCameraTests.cpp
@@ -183,3 +183,15 @@ TEST_F(OrbitalLineScanSensorModel, ReferenceDateTime) {
   std::string date = sensorModel->getReferenceDateAndTime();
   EXPECT_EQ(date, "20000101T001639");
 }
+
+TEST_F(OrbitalLineScanSensorModel, ComputeGroundPartials) {
+   csm::EcefCoord groundPt(1000000.0, 0.0, 0.0);
+   std::vector<double> partials = sensorModel->computeGroundPartials(groundPt);
+   ASSERT_EQ(partials.size(), 6);
+   EXPECT_NEAR(partials[0], 0.0, 1e-12);
+   EXPECT_NEAR(partials[1], 0.0, 1e-12);
+   EXPECT_NEAR(partials[2], -0.01, 1e-12);
+   EXPECT_NEAR(partials[3], 0.0, 1e-12);
+   EXPECT_NEAR(partials[4], -0.01, 1e-12);
+   EXPECT_NEAR(partials[5], 0.0, 1e-12);
+}


### PR DESCRIPTION
The ground partials are computed using finite differences. In some cases, the step size was too small to actually difference across multiple pixels which resulted in bad results. I bumped the step size up to 3 times the reference pixel resolution to help fix this. I also added a LS test.