### PR TITLE
Made LS image time continuous

### DIFF
--- a/tests/LineScanCameraTests.cpp
+++ b/tests/LineScanCameraTests.cpp
@@ -105,7 +105,7 @@ TEST_F(ConstVelocityLineScanSensorModel, calculateAttitudeCorrection) {
   double attCorr[9];
   adj.resize(15, 0);
   // Pi/2 with simply compensating for member variable m_flyingHeight in UsgsAstroLsSensorModel
-  adj[7] = (M_PI / 2) * 990.0496255790623081338708;
+  adj[7] = (M_PI / 2) * sensorModel->m_flyingHeight;
   sensorModel->calculateAttitudeCorrection(999.5, adj, attCorr);
 
   // EXPECT_NEARs are used here instead of EXPECT_DOUBLE_EQs because index 0 and 8 of the matrix
@@ -238,7 +238,7 @@ TEST_F(OrbitalLineScanSensorModel, InversionHeight) {
 TEST_F(OrbitalLineScanSensorModel, InversionReallyHigh) {
   for (double line = 0.5; line < 16; line++) {
     csm::ImageCoord imagePt(line, 8);
-    csm::EcefCoord groundPt = sensorModel->imageToGround(imagePt, 49000.0);
+    csm::EcefCoord groundPt = sensorModel->imageToGround(imagePt, 45000.0);
     csm::ImageCoord imageReprojPt = sensorModel->groundToImage(groundPt);
 
     // groundToImage has a default precision of 0.001m and each pixel is 2m


### PR DESCRIPTION
We were having issues with ground partials being inconsistent across the image, this makes them consistent.