### PR TITLE
SAR instantiation logic

### DIFF
--- a/include/usgscsm/UsgsAstroPlugin.h
+++ b/include/usgscsm/UsgsAstroPlugin.h
@@ -55,7 +55,6 @@ private:
     static const std::string _MANUFACTURER_NAME;
     static const std::string _RELEASE_DATE;
     static const int         _N_SENSOR_MODELS;
-    static const std::string _ISD_KEYWORD[];
 
     typedef csm::Model* (*sensorConstructor)(void);
     static std::map<std::string, sensorConstructor> MODELS;

--- a/include/usgscsm/UsgsAstroSarSensorModel.h
+++ b/include/usgscsm/UsgsAstroSarSensorModel.h
@@ -13,6 +13,8 @@ class UsgsAstroSarSensorModel : public csm::RasterGM, virtual public csm::Settab
     UsgsAstroSarSensorModel();
     ~UsgsAstroSarSensorModel();
 
+    void reset();
+
     virtual void replaceModelState(const std::string& argState);
 
     virtual std::string getModelState() const;
@@ -206,6 +208,7 @@ class UsgsAstroSarSensorModel : public csm::RasterGM, virtual public csm::Settab
     // Model state variables //
     ///////////////////////////
     std::string  m_imageIdentifier;
+    std::string  m_platformName;
     std::string  m_sensorName;
     int          m_nLines;
     int          m_nSamples;

--- a/include/usgscsm/UsgsAstroSarSensorModel.h
+++ b/include/usgscsm/UsgsAstroSarSensorModel.h
@@ -11,7 +11,7 @@ class UsgsAstroSarSensorModel : public csm::RasterGM, virtual public csm::Settab
   public:
 
     UsgsAstroSarSensorModel();
-    ~UsgsAstroSarSensorModel();
+    ~UsgsAstroSarSensorModel() {}
 
     void reset();
 
@@ -218,7 +218,6 @@ class UsgsAstroSarSensorModel : public csm::RasterGM, virtual public csm::Settab
     double       m_centerEphemerisTime;
     double       m_majorAxis;
     double       m_minorAxis;
-    std::string  m_referenceDateAndTime;
     std::string  m_platformIdentifier;
     std::string  m_sensorIdentifier;
     std::string  m_trajectoryIdentifier;

--- a/src/UsgsAstroPlugin.cpp
+++ b/src/UsgsAstroPlugin.cpp
@@ -297,23 +297,23 @@ csm::Model *UsgsAstroPlugin::constructModelFromISD(const csm::Isd &imageSupportD
       }
       return model;
     }
-    // else if (modelName == UsgsAstroSarSensorModel::_SENSOR_MODEL_NAME) {
-    //   UsgsAstroSarSensorModel *model =  new UsgsAstroSarSensorModel();
-    //   try {
-    //     model->replaceModelState(model->constructStateFromIsd(stringIsd, warnings));
-    //   }
-    //   catch (std::exception& e) {
-    //     csm::Error::ErrorType aErrorType = csm::Error::SENSOR_MODEL_NOT_CONSTRUCTIBLE;
-    //     std::string aMessage = "Could not construct model [";
-    //     aMessage += modelName;
-    //     aMessage += "] with error [";
-    //     aMessage += e.what();
-    //     aMessage += "]";
-    //     std::string aFunction = "UsgsAstroPlugin::constructModelFromISD()";
-    //     throw csm::Error(aErrorType, aMessage, aFunction);
-    //   }
-    //   return model;
-    // }
+    else if (modelName == UsgsAstroSarSensorModel::_SENSOR_MODEL_NAME) {
+      UsgsAstroSarSensorModel *model =  new UsgsAstroSarSensorModel();
+      try {
+        model->replaceModelState(model->constructStateFromIsd(stringIsd, warnings));
+      }
+      catch (std::exception& e) {
+        csm::Error::ErrorType aErrorType = csm::Error::SENSOR_MODEL_NOT_CONSTRUCTIBLE;
+        std::string aMessage = "Could not construct model [";
+        aMessage += modelName;
+        aMessage += "] with error [";
+        aMessage += e.what();
+        aMessage += "]";
+        std::string aFunction = "UsgsAstroPlugin::constructModelFromISD()";
+        throw csm::Error(aErrorType, aMessage, aFunction);
+      }
+      return model;
+    }
     else {
       csm::Error::ErrorType aErrorType = csm::Error::SENSOR_MODEL_NOT_SUPPORTED;
       std::string aMessage = "Model [" + modelName + "] not supported: ";
@@ -339,11 +339,11 @@ csm::Model *UsgsAstroPlugin::constructModelFromState(const std::string& modelSta
         model->replaceModelState(modelState);
         return model;
     }
-    // else if (modelName == UsgsAstroSarSensorModel::_SENSOR_MODEL_NAME) {
-    //     UsgsAstroSarSensorModel* model = new UsgsAstroSarSensorModel();
-    //     model->replaceModelState(modelState);
-    //     return model;
-    // }
+    else if (modelName == UsgsAstroSarSensorModel::_SENSOR_MODEL_NAME) {
+        UsgsAstroSarSensorModel* model = new UsgsAstroSarSensorModel();
+        model->replaceModelState(modelState);
+        return model;
+    }
     else {
       csm::Error::ErrorType aErrorType = csm::Error::ISD_NOT_SUPPORTED;
       std::string aMessage = "Model" + modelName + " not supported: ";

--- a/src/UsgsAstroPlugin.cpp
+++ b/src/UsgsAstroPlugin.cpp
@@ -2,6 +2,7 @@
 
 #include "UsgsAstroFrameSensorModel.h"
 #include "UsgsAstroLsSensorModel.h"
+#include "UsgsAstroSarSensorModel.h"
 
 #include <algorithm>
 #include <cstdlib>
@@ -29,33 +30,7 @@ using json = nlohmann::json;
 const std::string UsgsAstroPlugin::_PLUGIN_NAME = "UsgsAstroPluginCSM";
 const std::string UsgsAstroPlugin::_MANUFACTURER_NAME = "UsgsAstrogeology";
 const std::string UsgsAstroPlugin::_RELEASE_DATE = "20190222";
-const int         UsgsAstroPlugin::_N_SENSOR_MODELS = 2;
-
-const std::string UsgsAstroPlugin::_ISD_KEYWORD[] =
-{
-   "name_model",
-   "center_ephemeris_time",
-   "dt_ephemeris",
-   "focal2pixel_lines",
-   "focal2pixel_samples",
-   "focal_length_model",
-   "image_lines",
-   "image_samples",
-   "interpolation_method",
-   "number_of_ephemerides",
-   "optical_distortion",
-   "radii",
-   "reference_height",
-   "sensor_location_unit",
-   "sensor_location",
-   "sensor_orientation",
-   "sensor_velocity",
-   "detector_center",
-   "starting_detector_line",
-   "starting_detector_sample",
-   "starting_ephemeris_time",
-   "sun_position"
-};
+const int         UsgsAstroPlugin::_N_SENSOR_MODELS = 3;
 
 // Static Instance of itself
 const UsgsAstroPlugin UsgsAstroPlugin::m_registeredPlugin;
@@ -96,7 +71,8 @@ size_t UsgsAstroPlugin::getNumModels() const {
 std::string UsgsAstroPlugin::getModelName(size_t modelIndex) const {
   std::vector<std::string> supportedModelNames = {
     UsgsAstroFrameSensorModel::_SENSOR_MODEL_NAME,
-    UsgsAstroLsSensorModel::_SENSOR_MODEL_NAME
+    UsgsAstroLsSensorModel::_SENSOR_MODEL_NAME,
+    UsgsAstroSarSensorModel::_SENSOR_MODEL_NAME
   };
   return supportedModelNames[modelIndex];
 }
@@ -321,6 +297,23 @@ csm::Model *UsgsAstroPlugin::constructModelFromISD(const csm::Isd &imageSupportD
       }
       return model;
     }
+    // else if (modelName == UsgsAstroSarSensorModel::_SENSOR_MODEL_NAME) {
+    //   UsgsAstroSarSensorModel *model =  new UsgsAstroSarSensorModel();
+    //   try {
+    //     model->replaceModelState(model->constructStateFromIsd(stringIsd, warnings));
+    //   }
+    //   catch (std::exception& e) {
+    //     csm::Error::ErrorType aErrorType = csm::Error::SENSOR_MODEL_NOT_CONSTRUCTIBLE;
+    //     std::string aMessage = "Could not construct model [";
+    //     aMessage += modelName;
+    //     aMessage += "] with error [";
+    //     aMessage += e.what();
+    //     aMessage += "]";
+    //     std::string aFunction = "UsgsAstroPlugin::constructModelFromISD()";
+    //     throw csm::Error(aErrorType, aMessage, aFunction);
+    //   }
+    //   return model;
+    // }
     else {
       csm::Error::ErrorType aErrorType = csm::Error::SENSOR_MODEL_NOT_SUPPORTED;
       std::string aMessage = "Model [" + modelName + "] not supported: ";
@@ -346,6 +339,11 @@ csm::Model *UsgsAstroPlugin::constructModelFromState(const std::string& modelSta
         model->replaceModelState(modelState);
         return model;
     }
+    // else if (modelName == UsgsAstroSarSensorModel::_SENSOR_MODEL_NAME) {
+    //     UsgsAstroSarSensorModel* model = new UsgsAstroSarSensorModel();
+    //     model->replaceModelState(modelState);
+    //     return model;
+    // }
     else {
       csm::Error::ErrorType aErrorType = csm::Error::ISD_NOT_SUPPORTED;
       std::string aMessage = "Model" + modelName + " not supported: ";

--- a/src/UsgsAstroSarSensorModel.cpp
+++ b/src/UsgsAstroSarSensorModel.cpp
@@ -39,14 +39,12 @@ const csm::param::Type
 
 string UsgsAstroSarSensorModel::constructStateFromIsd(
     const string imageSupportData,
-    csm::WarningList *warnings
-) {
+    csm::WarningList *warnings)
+{
   json isd = json::parse(imageSupportData);
   json state = {};
 
   csm::WarningList* parsingWarnings = new csm::WarningList;
-
-  int num_params = NUM_PARAMETERS;
 
   state["m_modelName"] = getSensorModelName(isd, parsingWarnings);
   state["m_imageIdentifier"] = getImageId(isd, parsingWarnings);
@@ -57,11 +55,11 @@ string UsgsAstroSarSensorModel::constructStateFromIsd(
   state["m_nSamples"] = getTotalSamples(isd, parsingWarnings);
 
   // Zero computed state values
-  state["m_referencePointXyz"] = std::vector<double>(3, 0.0);
+  state["m_referencePointXyz"] = vector<double>(3, 0.0);
 
   // sun_position and velocity are required for getIlluminationDirection
-  state["m_sunPosition"]= getSunPositions(isd, parsingWarnings);
-  state["m_sunVelocity"]= getSunVelocities(isd, parsingWarnings);
+  state["m_sunPosition"] = getSunPositions(isd, parsingWarnings);
+  state["m_sunVelocity"] = getSunVelocities(isd, parsingWarnings);
 
   state["m_centerEphemerisTime"] = getCenterTime(isd, parsingWarnings);
   state["m_startingEphemerisTime"] = getStartingTime(isd, parsingWarnings);
@@ -93,7 +91,7 @@ string UsgsAstroSarSensorModel::constructStateFromIsd(
   state["m_positions"] = getSensorPositions(isd, parsingWarnings);
   state["m_velocities"] = getSensorVelocities(isd, parsingWarnings);
 
-  state["m_currentParameterValue"] = std::vector<double>(NUM_PARAMETERS, 0.0);
+  state["m_currentParameterValue"] = vector<double>(NUM_PARAMETERS, 0.0);
 
   // get radii
   state["m_minorAxis"] = getSemiMinorRadius(isd, parsingWarnings);
@@ -113,7 +111,7 @@ string UsgsAstroSarSensorModel::constructStateFromIsd(
 
   // Default to identity covariance
   state["m_covariance"] =
-       std::vector<double>(NUM_PARAMETERS * NUM_PARAMETERS, 0.0);
+       vector<double>(NUM_PARAMETERS * NUM_PARAMETERS, 0.0);
   for (int i = 0; i < NUM_PARAMETERS; i++) {
    state["m_covariance"][i * NUM_PARAMETERS + i] = 1.0;
   }
@@ -135,4 +133,221 @@ string UsgsAstroSarSensorModel::constructStateFromIsd(
   // The state data will still be updated when a sensor model is created since
   // some state data is not in the ISD and requires a SM to compute them.
   return state.dump();
+}
+
+string UsgsAstroSarSensorModel::getModelNameFromModelState(const string& model_state)
+{
+   // Parse the string to JSON
+   auto j = json::parse(model_state);
+   // If model name cannot be determined, return a blank string
+   std::string model_name;
+
+   if (j.find("m_modelName") != j.end()) {
+       model_name = j["m_modelName"];
+   } else {
+       csm::Error::ErrorType aErrorType = csm::Error::INVALID_SENSOR_MODEL_STATE;
+       std::string aMessage = "No 'm_modelName' key in the model state object.";
+       std::string aFunction = "UsgsAstroSarSensorModel::getModelNameFromModelState";
+       csm::Error csmErr(aErrorType, aMessage, aFunction);
+       throw(csmErr);
+   }
+   if (model_name != _SENSOR_MODEL_NAME){
+       csm::Error::ErrorType aErrorType = csm::Error::SENSOR_MODEL_NOT_SUPPORTED;
+       std::string aMessage = "Sensor model not supported.";
+       std::string aFunction = "UsgsAstroSarSensorModel::getModelNameFromModelState()";
+       csm::Error csmErr(aErrorType, aMessage, aFunction);
+       throw(csmErr);
+   }
+   return model_name;
+
+}
+
+void UsgsAstroSarSensorModel::reset()
+{
+  m_imageIdentifier = "Unknown";
+  m_sensorName = "Unknown";
+  m_platformIdentifier = "Unknown";
+  m_nLines = 0;
+  m_nSamples = 0;
+  m_exposureDuration = 0;
+  m_scaledPixelWidth = 0;
+  m_startingEphemerisTime = 0;
+  m_centerEphemerisTime = 0;
+  m_majorAxis = 0;
+  m_minorAxis = 0;
+  m_referenceDateAndTime = "Unknown";
+  m_platformIdentifier = "Unknown";
+  m_sensorIdentifier = "Unknown";
+  m_trajectoryIdentifier = "Unknown";
+  m_collectionIdentifier = "Unknown";
+  m_refElevation = 0;
+  m_minElevation = -1000;
+  m_maxElevation = 1000;
+  m_dtEphem = 0;
+  m_t0Ephem = 0;
+  m_scaleConversionCoefficients.clear();
+  m_positions.clear();
+  m_velocities.clear();
+  m_currentParameterValue = vector<double>(NUM_PARAMETERS, 0.0);
+  m_parameterType = vector<csm::param::Type>(NUM_PARAMETERS, csm::param::REAL);
+  m_referencePointXyz.x = 0.0;
+  m_referencePointXyz.y = 0.0;
+  m_referencePointXyz.z = 0.0;
+  m_covariance = vector<double>(NUM_PARAMETERS * NUM_PARAMETERS,0.0);
+  m_sunPosition.clear();
+  m_sunVelocity.clear();
+}
+
+void UsgsAstroSarSensorModel::replaceModelState(const string& argState)
+{
+  reset();
+
+  auto stateJson = json::parse(argState);
+
+  m_imageIdentifier = stateJson["m_imageIdentifier"].get<string>();
+  m_platformIdentifier = stateJson["m_platformIdentifier"].get<string>();
+  m_sensorName = stateJson["m_sensorName"].get<string>();
+  m_nLines = stateJson["m_nLines"];
+  m_nSamples = stateJson["m_nSamples"];
+  m_exposureDuration = stateJson["m_exposureDuration"];
+  m_scaledPixelWidth = stateJson["m_scaledPixelWidth"];
+  m_startingEphemerisTime = stateJson["m_startingEphemerisTime"];
+  m_centerEphemerisTime = stateJson["m_centerEphemerisTime"];
+  m_majorAxis = stateJson["m_majorAxis"];
+  m_minorAxis = stateJson["m_minorAxis"];
+  m_referenceDateAndTime = stateJson["m_referenceDateAndTime"].get<string>();
+  m_platformIdentifier = stateJson["m_platformIdentifier"].get<string>();
+  m_sensorIdentifier = stateJson["m_sensorIdentifier"].get<string>();
+  m_trajectoryIdentifier = stateJson["m_trajectoryIdentifier"].get<string>();
+  m_collectionIdentifier = stateJson["m_collectionIdentifier"].get<string>();
+  m_refElevation = stateJson["m_refElevation"];
+  m_minElevation = stateJson["m_minElevation"];
+  m_maxElevation = stateJson["m_maxElevation"];
+  m_dtEphem = stateJson["m_dtEphem"];
+  m_t0Ephem = stateJson["m_t0Ephem"];
+  m_scaleConversionCoefficients = stateJson["m_scaleConversionCoefficients"].get<vector<double>>();
+  m_positions = stateJson["m_positions"].get<vector<double>>();
+  m_velocities = stateJson["m_velocities"].get<vector<double>>();
+  m_currentParameterValue = stateJson["m_currentParameterValue"].get<vector<double>>();
+  m_referencePointXyz.x = stateJson["m_referencePointXyz"][0];
+  m_referencePointXyz.y = stateJson["m_referencePointXyz"][1];
+  m_referencePointXyz.z = stateJson["m_referencePointXyz"][2];
+  m_covariance = stateJson["m_covariance"].get<vector<double>>();
+  m_sunPosition = stateJson["m_sunPosition"].get<vector<double>>();;
+  m_sunVelocity = stateJson["m_sunVelocity"].get<vector<double>>();;
+}
+
+string UsgsAstroSarSensorModel::getModelState() const
+{
+  json state = {};
+
+  state["m_modelName"] = _SENSOR_MODEL_NAME;
+  state["m_imageIdentifier"] = m_imageIdentifier;
+  state["m_sensorName"] = m_sensorName;
+  state["m_platformName"] = m_platformName;
+  state["m_nLines"] = m_nLines;
+  state["m_nSamples"] = m_nSamples;
+  state["m_referencePointXyz"] = {
+      m_referencePointXyz.x,
+      m_referencePointXyz.y,
+      m_referencePointXyz.z
+  };
+  state["m_sunPosition"] = m_sunPosition;
+  state["m_sunVelocity"] = m_sunVelocity;
+  state["m_centerEphemerisTime"] = m_centerEphemerisTime;
+  state["m_startingEphemerisTime"] = m_startingEphemerisTime;
+  state["m_exposureDuration"] = m_exposureDuration;
+  state["m_dtEphem"] = m_dtEphem;
+  state["m_t0Ephem"] = m_t0Ephem;
+  state["m_positions"] = m_positions;
+  state["m_velocities"] = m_velocities;
+  state["m_currentParameterValue"] = m_currentParameterValue;
+  state["m_minorAxis"] = m_minorAxis;
+  state["m_majorAxis"] = m_majorAxis;
+  state["m_platformIdentifier"] = m_platformIdentifier;
+  state["m_sensorIdentifier"] = m_sensorIdentifier;
+  state["m_minElevation"] = m_minElevation;
+  state["m_maxElevation"] = m_maxElevation;
+  state["m_scaledPixelWidth"] = m_scaledPixelWidth;
+  state["m_scaleConversionCoefficients"] = m_scaleConversionCoefficients;
+  state["m_covariance"] = m_covariance;
+
+  return state.dump();
+}
+
+
+
+csm::ImageCoord UsgsAstroSarSensorModel::groundToImage(
+    const csm::EcefCoord& groundPt,
+    double desiredPrecision,
+    double* achievedPrecision,
+    csm::WarningList* warnings) const
+{
+  return csm::ImageCoord(0.0, 0.0);
+}
+
+csm::ImageCoordCovar UsgsAstroSarSensorModel::groundToImage(
+    const csm::EcefCoordCovar& groundPt,
+    double desiredPrecision,
+    double* achievedPrecision,
+    csm::WarningList* warnings) const
+{
+  return csm::ImageCoordCovar(0.0, 0.0,
+                              1.0, 0.0,
+                                   1.0);
+}
+
+csm::EcefCoord UsgsAstroSarSensorModel::imageToGround(
+    const csm::ImageCoord& imagePt,
+    double height,
+    double desiredPrecision,
+    double* achievedPrecision,
+    csm::WarningList* warnings) const
+{
+  return csm::EcefCoord(0.0, 0.0, 0.0);
+}
+
+csm::EcefCoordCovar UsgsAstroSarSensorModel::imageToGround(
+    const csm::ImageCoordCovar& imagePt,
+    double height,
+    double heightVariance,
+    double desiredPrecision,
+    double* achievedPrecision,
+    csm::WarningList* warnings) const
+{
+  return csm::EcefCoordCovar(0.0, 0.0, 0.0,
+                             1.0, 0.0, 0.0,
+                                  1.0, 0.0,
+                                       1.0);
+}
+
+csm::EcefLocus UsgsAstroSarSensorModel::imageToProximateImagingLocus(
+    const csm::ImageCoord& imagePt,
+    const csm::EcefCoord& groundPt,
+    double desiredPrecision,
+    double* achievedPrecision,
+    csm::WarningList* warnings) const
+{
+  return csm::EcefLocus(0.0, 0.0, 0.0,
+                        0.0, 0.0, 0.0);
+}
+
+csm::EcefLocus UsgsAstroSarSensorModel::imageToRemoteImagingLocus(
+    const csm::ImageCoord& imagePt,
+    double desiredPrecision,
+    double* achievedPrecision,
+    csm::WarningList* warnings) const
+{
+  return csm::EcefLocus(0.0, 0.0, 0.0,
+                        0.0, 0.0, 0.0);
+}
+
+csm::ImageCoord UsgsAstroSarSensorModel::getImageStart() const
+{
+  return csm::ImageCoord(0.0, 0.0);
+}
+
+csm::ImageVector UsgsAstroSarSensorModel::getImageSize() const
+{
+  return csm::ImageVector(0.0, 0.0);
 }

--- a/src/UsgsAstroSarSensorModel.cpp
+++ b/src/UsgsAstroSarSensorModel.cpp
@@ -140,26 +140,31 @@ string UsgsAstroSarSensorModel::getModelNameFromModelState(const string& model_s
    // Parse the string to JSON
    auto j = json::parse(model_state);
    // If model name cannot be determined, return a blank string
-   std::string model_name;
+   string model_name;
 
    if (j.find("m_modelName") != j.end()) {
        model_name = j["m_modelName"];
    } else {
        csm::Error::ErrorType aErrorType = csm::Error::INVALID_SENSOR_MODEL_STATE;
-       std::string aMessage = "No 'm_modelName' key in the model state object.";
-       std::string aFunction = "UsgsAstroSarSensorModel::getModelNameFromModelState";
+       string aMessage = "No 'm_modelName' key in the model state object.";
+       string aFunction = "UsgsAstroSarSensorModel::getModelNameFromModelState";
        csm::Error csmErr(aErrorType, aMessage, aFunction);
        throw(csmErr);
    }
    if (model_name != _SENSOR_MODEL_NAME){
        csm::Error::ErrorType aErrorType = csm::Error::SENSOR_MODEL_NOT_SUPPORTED;
-       std::string aMessage = "Sensor model not supported.";
-       std::string aFunction = "UsgsAstroSarSensorModel::getModelNameFromModelState()";
+       string aMessage = "Sensor model not supported.";
+       string aFunction = "UsgsAstroSarSensorModel::getModelNameFromModelState()";
        csm::Error csmErr(aErrorType, aMessage, aFunction);
        throw(csmErr);
    }
    return model_name;
 
+}
+
+UsgsAstroSarSensorModel::UsgsAstroSarSensorModel()
+{
+  reset();
 }
 
 void UsgsAstroSarSensorModel::reset()
@@ -175,12 +180,10 @@ void UsgsAstroSarSensorModel::reset()
   m_centerEphemerisTime = 0;
   m_majorAxis = 0;
   m_minorAxis = 0;
-  m_referenceDateAndTime = "Unknown";
   m_platformIdentifier = "Unknown";
   m_sensorIdentifier = "Unknown";
   m_trajectoryIdentifier = "Unknown";
   m_collectionIdentifier = "Unknown";
-  m_refElevation = 0;
   m_minElevation = -1000;
   m_maxElevation = 1000;
   m_dtEphem = 0;
@@ -215,12 +218,8 @@ void UsgsAstroSarSensorModel::replaceModelState(const string& argState)
   m_centerEphemerisTime = stateJson["m_centerEphemerisTime"];
   m_majorAxis = stateJson["m_majorAxis"];
   m_minorAxis = stateJson["m_minorAxis"];
-  m_referenceDateAndTime = stateJson["m_referenceDateAndTime"].get<string>();
   m_platformIdentifier = stateJson["m_platformIdentifier"].get<string>();
   m_sensorIdentifier = stateJson["m_sensorIdentifier"].get<string>();
-  m_trajectoryIdentifier = stateJson["m_trajectoryIdentifier"].get<string>();
-  m_collectionIdentifier = stateJson["m_collectionIdentifier"].get<string>();
-  m_refElevation = stateJson["m_refElevation"];
   m_minElevation = stateJson["m_minElevation"];
   m_maxElevation = stateJson["m_maxElevation"];
   m_dtEphem = stateJson["m_dtEphem"];
@@ -233,8 +232,8 @@ void UsgsAstroSarSensorModel::replaceModelState(const string& argState)
   m_referencePointXyz.y = stateJson["m_referencePointXyz"][1];
   m_referencePointXyz.z = stateJson["m_referencePointXyz"][2];
   m_covariance = stateJson["m_covariance"].get<vector<double>>();
-  m_sunPosition = stateJson["m_sunPosition"].get<vector<double>>();;
-  m_sunVelocity = stateJson["m_sunVelocity"].get<vector<double>>();;
+  m_sunPosition = stateJson["m_sunPosition"].get<vector<double>>();
+  m_sunVelocity = stateJson["m_sunVelocity"].get<vector<double>>();
 }
 
 string UsgsAstroSarSensorModel::getModelState() const
@@ -350,4 +349,311 @@ csm::ImageCoord UsgsAstroSarSensorModel::getImageStart() const
 csm::ImageVector UsgsAstroSarSensorModel::getImageSize() const
 {
   return csm::ImageVector(0.0, 0.0);
+}
+
+pair<csm::ImageCoord, csm::ImageCoord> UsgsAstroSarSensorModel::getValidImageRange() const
+{
+  return make_pair(csm::ImageCoord(0.0, 0.0), csm::ImageCoord(0.0, 0.0));
+}
+
+pair<double, double> UsgsAstroSarSensorModel::getValidHeightRange() const
+{
+  return make_pair(0.0, 0.0);
+}
+
+csm::EcefVector UsgsAstroSarSensorModel::getIlluminationDirection(const csm::EcefCoord& groundPt) const
+{
+  return csm::EcefVector(0.0, 0.0, 0.0);
+}
+
+double UsgsAstroSarSensorModel::getImageTime(const csm::ImageCoord& imagePt) const
+{
+  return 0.0;
+}
+
+csm::EcefCoord UsgsAstroSarSensorModel::getSensorPosition(const csm::ImageCoord& imagePt) const
+{
+  return csm::EcefCoord(0.0, 0.0, 0.0);
+}
+
+csm::EcefCoord UsgsAstroSarSensorModel::getSensorPosition(double time) const
+{
+  return csm::EcefCoord(0.0, 0.0, 0.0);
+}
+
+csm::EcefVector UsgsAstroSarSensorModel::getSensorVelocity(const csm::ImageCoord& imagePt) const
+{
+  return csm::EcefVector(0.0, 0.0, 0.0);
+}
+
+csm::EcefVector UsgsAstroSarSensorModel::getSensorVelocity(double time) const
+{
+  return csm::EcefVector(0.0, 0.0, 0.0);
+}
+
+csm::RasterGM::SensorPartials UsgsAstroSarSensorModel::computeSensorPartials(
+    int index,
+    const csm::EcefCoord& groundPt,
+    double desiredPrecision,
+    double* achievedPrecision,
+    csm::WarningList* warnings) const
+{
+  return csm::RasterGM::SensorPartials(0.0, 0.0);
+}
+
+csm::RasterGM::SensorPartials UsgsAstroSarSensorModel::computeSensorPartials(
+    int index,
+    const csm::ImageCoord& imagePt,
+    const csm::EcefCoord& groundPt,
+    double desiredPrecision,
+    double* achievedPrecision,
+    csm::WarningList* warnings) const
+{
+  return csm::RasterGM::SensorPartials(0.0, 0.0);
+}
+
+vector<csm::RasterGM::SensorPartials> UsgsAstroSarSensorModel::computeAllSensorPartials(
+    const csm::EcefCoord& groundPt,
+    csm::param::Set pSet,
+    double desiredPrecision,
+    double* achievedPrecision,
+    csm::WarningList* warnings) const
+{
+  return vector<csm::RasterGM::SensorPartials>(NUM_PARAMETERS, csm::RasterGM::SensorPartials(0.0, 0.0));
+}
+
+vector<double> UsgsAstroSarSensorModel::computeGroundPartials(const csm::EcefCoord& groundPt) const
+{
+  return vector<double>(6, 0.0);
+}
+
+const csm::CorrelationModel& UsgsAstroSarSensorModel::getCorrelationModel() const
+{
+  return _NO_CORR_MODEL;
+}
+
+vector<double> UsgsAstroSarSensorModel::getUnmodeledCrossCovariance(
+    const csm::ImageCoord& pt1,
+    const csm::ImageCoord& pt2) const
+{
+  return vector<double>(4, 0.0);
+}
+
+csm::EcefCoord UsgsAstroSarSensorModel::getReferencePoint() const
+{
+  return m_referencePointXyz;
+}
+
+void UsgsAstroSarSensorModel::setReferencePoint(const csm::EcefCoord& groundPt)
+{
+  m_referencePointXyz = groundPt;
+}
+
+int UsgsAstroSarSensorModel::getNumParameters() const
+{
+  return NUM_PARAMETERS;
+}
+
+string UsgsAstroSarSensorModel::getParameterName(int index) const
+{
+  return PARAMETER_NAME[index];
+}
+
+string UsgsAstroSarSensorModel::getParameterUnits(int index) const
+{
+  return "m";
+}
+
+bool UsgsAstroSarSensorModel::hasShareableParameters() const
+{
+  return false;
+}
+
+bool UsgsAstroSarSensorModel::isParameterShareable(int index) const
+{
+  return false;
+}
+
+csm::SharingCriteria UsgsAstroSarSensorModel::getParameterSharingCriteria(int index) const
+{
+  return csm::SharingCriteria();
+}
+
+double UsgsAstroSarSensorModel::getParameterValue(int index) const
+{
+  return m_currentParameterValue[index];
+}
+
+void UsgsAstroSarSensorModel::setParameterValue(int index, double value)
+{
+  m_currentParameterValue[index] = value;
+}
+
+csm::param::Type UsgsAstroSarSensorModel::getParameterType(int index) const
+{
+  return m_parameterType[index];
+}
+
+void UsgsAstroSarSensorModel::setParameterType(int index, csm::param::Type pType)
+{
+  m_parameterType[index] = pType;
+}
+
+double UsgsAstroSarSensorModel::getParameterCovariance(
+    int index1,
+    int index2) const
+{
+  return m_covariance[index1 * NUM_PARAMETERS + index2];
+}
+
+
+void UsgsAstroSarSensorModel::setParameterCovariance(
+    int index1,
+    int index2,
+    double covariance)
+
+{
+  m_covariance[index1 * NUM_PARAMETERS + index2] = covariance;
+}
+
+int UsgsAstroSarSensorModel::getNumGeometricCorrectionSwitches() const
+{
+  return 0;
+}
+
+string UsgsAstroSarSensorModel::getGeometricCorrectionName(int index) const
+{
+  throw csm::Error(
+     csm::Error::INDEX_OUT_OF_RANGE,
+     "Index is out of range.",
+     "UsgsAstroSarSensorModel::getGeometricCorrectionName");
+}
+
+void UsgsAstroSarSensorModel::setGeometricCorrectionSwitch(int index,
+    bool value,
+    csm::param::Type pType)
+{
+  throw csm::Error(
+     csm::Error::INDEX_OUT_OF_RANGE,
+     "Index is out of range.",
+     "UsgsAstroSarSensorModel::setGeometricCorrectionSwitch");
+}
+
+bool UsgsAstroSarSensorModel::getGeometricCorrectionSwitch(int index) const
+{
+  throw csm::Error(
+     csm::Error::INDEX_OUT_OF_RANGE,
+     "Index is out of range.",
+     "UsgsAstroSarSensorModel::getGeometricCorrectionSwitch");
+}
+
+vector<double> UsgsAstroSarSensorModel::getCrossCovarianceMatrix(
+    const csm::GeometricModel& comparisonModel,
+    csm::param::Set pSet,
+    const csm::GeometricModel::GeometricModelList& otherModels) const
+{
+  // Return covariance matrix
+  if (&comparisonModel == this) {
+    vector<int> paramIndices = getParameterSetIndices(pSet);
+    int numParams = paramIndices.size();
+    vector<double> covariances(numParams * numParams, 0.0);
+    for (int i = 0; i < numParams; i++) {
+      for (int j = 0; j < numParams; j++) {
+        covariances[i * numParams + j] = getParameterCovariance(paramIndices[i], paramIndices[j]);
+      }
+    }
+    return covariances;
+  }
+  // No correlation between models.
+  const vector<int>& indices = getParameterSetIndices(pSet);
+  size_t num_rows = indices.size();
+  const vector<int>& indices2 = comparisonModel.getParameterSetIndices(pSet);
+  size_t num_cols = indices.size();
+
+  return vector<double>(num_rows * num_cols, 0.0);
+}
+
+csm::Version UsgsAstroSarSensorModel::getVersion() const
+{
+  return csm::Version(1, 0, 0);
+}
+
+string UsgsAstroSarSensorModel::getModelName() const
+{
+  return _SENSOR_MODEL_NAME;
+}
+
+string UsgsAstroSarSensorModel::getPedigree() const
+{
+  return "USGS_SAR";
+}
+
+string UsgsAstroSarSensorModel::getImageIdentifier() const
+{
+  return m_imageIdentifier;
+}
+
+void UsgsAstroSarSensorModel::setImageIdentifier(
+    const string& imageId,
+    csm::WarningList* warnings)
+{
+  m_imageIdentifier = imageId;
+}
+
+string UsgsAstroSarSensorModel::getSensorIdentifier() const
+{
+  return m_sensorIdentifier;
+}
+
+string UsgsAstroSarSensorModel::getPlatformIdentifier() const
+{
+  return m_platformIdentifier;
+}
+
+string UsgsAstroSarSensorModel::getCollectionIdentifier() const
+{
+  return m_collectionIdentifier;
+}
+
+string UsgsAstroSarSensorModel::getTrajectoryIdentifier() const
+{
+  return m_trajectoryIdentifier;
+}
+
+string UsgsAstroSarSensorModel::getSensorType() const
+{
+  return "SAR";
+}
+
+string UsgsAstroSarSensorModel::getSensorMode() const
+{
+  return "STRIP";
+}
+
+string UsgsAstroSarSensorModel::getReferenceDateAndTime() const
+{
+  csm::ImageCoord referencePointImage = groundToImage(m_referencePointXyz);
+  double relativeTime = getImageTime(referencePointImage);
+  time_t ephemTime = m_centerEphemerisTime + relativeTime;
+  struct tm t = {0};  // Initalize to all 0's
+  t.tm_year = 100;  // This is year-1900, so 100 = 2000
+  t.tm_mday = 1;
+  time_t timeSinceEpoch = mktime(&t);
+  time_t finalTime = ephemTime + timeSinceEpoch;
+  char buffer [16];
+  strftime(buffer, 16, "%Y%m%dT%H%M%S", localtime(&finalTime));
+  buffer[15] = '\0';
+
+  return buffer;
+}
+
+csm::Ellipsoid UsgsAstroSarSensorModel::getEllipsoid() const
+{
+   return csm::Ellipsoid(m_majorAxis, m_minorAxis);
+}
+
+void UsgsAstroSarSensorModel::setEllipsoid(const csm::Ellipsoid &ellipsoid)
+{
+   m_majorAxis = ellipsoid.getSemiMajorRadius();
+   m_minorAxis = ellipsoid.getSemiMinorRadius();
 }

--- a/tests/PluginTests.cpp
+++ b/tests/PluginTests.cpp
@@ -200,69 +200,84 @@ TEST_F(ConstVelLineScanIsdTest, ConstructInValidCamera) {
    }
 }
 
-// Commented out until all of the abstract methods are implemented
+TEST_F(SarIsdTest, Constructible) {
+  UsgsAstroPlugin testPlugin;
+  csm::WarningList warnings;
+  EXPECT_TRUE(testPlugin.canModelBeConstructedFromISD(
+              isd,
+              "USGS_ASTRO_SAR_SENSOR_MODEL",
+              &warnings));
+  for (auto &warn: warnings) {
+    std::cerr << "Warning in " << warn.getFunction() << std::endl;
+    std::cerr << "  " << warn.getMessage() << std::endl;
+  }
+}
 
-// TEST_F(SarIsdTest, Constructible) {
-//    UsgsAstroPlugin testPlugin;
-//    EXPECT_TRUE(testPlugin.canModelBeConstructedFromISD(
-//                isd,
-//                "USGS_ASTRO_SAR_SENSOR_MODEL"));
-// }
-//
-// TEST_F(SarIsdTest, ConstructibleFromState) {
-//    UsgsAstroPlugin testPlugin;
-//    std::string modelState = testPlugin.getStateFromISD(isd);
-//    EXPECT_TRUE(testPlugin.canModelBeConstructedFromState(
-//          "USGS_ASTRO_SAR_SENSOR_MODEL",
-//          modelState));
-// }
-//
-// TEST_F(SarIsdTest, NotConstructible) {
-//    UsgsAstroPlugin testPlugin;
-//    isd.setFilename("data/simpleFramerISD.img");
-//    EXPECT_FALSE(testPlugin.canModelBeConstructedFromISD(
-//                isd,
-//                "USGS_ASTRO_SAR_SENSOR_MODEL"));
-// }
-//
-// TEST_F(SarIsdTest, ConstructValidCamera) {
-//    UsgsAstroPlugin testPlugin;
-//    csm::Model *cameraModel = NULL;
-//    EXPECT_NO_THROW(
-//          cameraModel = testPlugin.constructModelFromISD(
-//                isd,
-//                "USGS_ASTRO_SAR_SENSOR_MODEL",
-//                NULL)
-//    );
-//    UsgsAstroSarSensorModel *sarModel = dynamic_cast<UsgsAstroSarSensorModel *>(cameraModel);
-//    EXPECT_NE(sarModel, nullptr);
-//    if (cameraModel) {
-//       delete cameraModel;
-//    }
-// }
-//
-// TEST_F(SarIsdTest, ConstructInValidCamera) {
-//    UsgsAstroPlugin testPlugin;
-//    isd.setFilename("data/empty.img");
-//    csm::Model *cameraModel = NULL;
-//    try {
-//       testPlugin.constructModelFromISD(
-//             isd,
-//             "USGS_ASTRO_SAR_SENSOR_MODEL",
-//             nullptr);
-//       FAIL() << "Expected an error";
-//
-//    }
-//    catch(csm::Error &e) {
-//       EXPECT_EQ(e.getError(), csm::Error::SENSOR_MODEL_NOT_CONSTRUCTIBLE);
-//    }
-//    catch(...) {
-//       FAIL() << "Expected csm SENSOR_MODEL_NOT_CONSTRUCTIBLE error";
-//    }
-//    if (cameraModel) {
-//       delete cameraModel;
-//    }
-// }
+TEST_F(SarIsdTest, ConstructibleFromState) {
+   UsgsAstroPlugin testPlugin;
+   csm::WarningList warnings;
+   std::string modelState = testPlugin.getStateFromISD(isd);
+   EXPECT_TRUE(testPlugin.canModelBeConstructedFromState(
+         "USGS_ASTRO_SAR_SENSOR_MODEL",
+         modelState,
+         &warnings));
+  for (auto &warn: warnings) {
+    std::cerr << "Warning in " << warn.getFunction() << std::endl;
+    std::cerr << "  " << warn.getMessage() << std::endl;
+  }
+}
+
+TEST_F(SarIsdTest, NotConstructible) {
+   UsgsAstroPlugin testPlugin;
+   isd.setFilename("data/simpleFramerISD.img");
+   EXPECT_FALSE(testPlugin.canModelBeConstructedFromISD(
+               isd,
+               "USGS_ASTRO_SAR_SENSOR_MODEL"));
+}
+
+TEST_F(SarIsdTest, ConstructValidCamera) {
+   UsgsAstroPlugin testPlugin;
+   csm::WarningList warnings;
+   csm::Model *cameraModel = NULL;
+   EXPECT_NO_THROW(
+         cameraModel = testPlugin.constructModelFromISD(
+               isd,
+               "USGS_ASTRO_SAR_SENSOR_MODEL",
+               &warnings)
+   );
+   for (auto &warn: warnings) {
+     std::cerr << "Warning in " << warn.getFunction() << std::endl;
+     std::cerr << "  " << warn.getMessage() << std::endl;
+   }
+   UsgsAstroSarSensorModel *sarModel = dynamic_cast<UsgsAstroSarSensorModel *>(cameraModel);
+   EXPECT_NE(sarModel, nullptr);
+   if (cameraModel) {
+      delete cameraModel;
+   }
+}
+
+TEST_F(SarIsdTest, ConstructInValidCamera) {
+   UsgsAstroPlugin testPlugin;
+   isd.setFilename("data/empty.img");
+   csm::Model *cameraModel = NULL;
+   try {
+      testPlugin.constructModelFromISD(
+            isd,
+            "USGS_ASTRO_SAR_SENSOR_MODEL",
+            nullptr);
+      FAIL() << "Expected an error";
+
+   }
+   catch(csm::Error &e) {
+      EXPECT_EQ(e.getError(), csm::Error::SENSOR_MODEL_NOT_CONSTRUCTIBLE);
+   }
+   catch(...) {
+      FAIL() << "Expected csm SENSOR_MODEL_NOT_CONSTRUCTIBLE error";
+   }
+   if (cameraModel) {
+      delete cameraModel;
+   }
+}
 
 int main(int argc, char **argv) {
    ::testing::InitGoogleTest(&argc, argv);

--- a/tests/PluginTests.cpp
+++ b/tests/PluginTests.cpp
@@ -26,7 +26,7 @@ TEST(PluginTests, ReleaseDate) {
 
 TEST(PluginTests, NumModels) {
    UsgsAstroPlugin testPlugin;
-   EXPECT_EQ(2, testPlugin.getNumModels());
+   EXPECT_EQ(3, testPlugin.getNumModels());
 }
 
 TEST(PluginTests, BadISDFile) {
@@ -199,6 +199,70 @@ TEST_F(ConstVelLineScanIsdTest, ConstructInValidCamera) {
       delete cameraModel;
    }
 }
+
+// Commented out until all of the abstract methods are implemented
+
+// TEST_F(SarIsdTest, Constructible) {
+//    UsgsAstroPlugin testPlugin;
+//    EXPECT_TRUE(testPlugin.canModelBeConstructedFromISD(
+//                isd,
+//                "USGS_ASTRO_SAR_SENSOR_MODEL"));
+// }
+//
+// TEST_F(SarIsdTest, ConstructibleFromState) {
+//    UsgsAstroPlugin testPlugin;
+//    std::string modelState = testPlugin.getStateFromISD(isd);
+//    EXPECT_TRUE(testPlugin.canModelBeConstructedFromState(
+//          "USGS_ASTRO_SAR_SENSOR_MODEL",
+//          modelState));
+// }
+//
+// TEST_F(SarIsdTest, NotConstructible) {
+//    UsgsAstroPlugin testPlugin;
+//    isd.setFilename("data/simpleFramerISD.img");
+//    EXPECT_FALSE(testPlugin.canModelBeConstructedFromISD(
+//                isd,
+//                "USGS_ASTRO_SAR_SENSOR_MODEL"));
+// }
+//
+// TEST_F(SarIsdTest, ConstructValidCamera) {
+//    UsgsAstroPlugin testPlugin;
+//    csm::Model *cameraModel = NULL;
+//    EXPECT_NO_THROW(
+//          cameraModel = testPlugin.constructModelFromISD(
+//                isd,
+//                "USGS_ASTRO_SAR_SENSOR_MODEL",
+//                NULL)
+//    );
+//    UsgsAstroSarSensorModel *sarModel = dynamic_cast<UsgsAstroSarSensorModel *>(cameraModel);
+//    EXPECT_NE(sarModel, nullptr);
+//    if (cameraModel) {
+//       delete cameraModel;
+//    }
+// }
+//
+// TEST_F(SarIsdTest, ConstructInValidCamera) {
+//    UsgsAstroPlugin testPlugin;
+//    isd.setFilename("data/empty.img");
+//    csm::Model *cameraModel = NULL;
+//    try {
+//       testPlugin.constructModelFromISD(
+//             isd,
+//             "USGS_ASTRO_SAR_SENSOR_MODEL",
+//             nullptr);
+//       FAIL() << "Expected an error";
+//
+//    }
+//    catch(csm::Error &e) {
+//       EXPECT_EQ(e.getError(), csm::Error::SENSOR_MODEL_NOT_CONSTRUCTIBLE);
+//    }
+//    catch(...) {
+//       FAIL() << "Expected csm SENSOR_MODEL_NOT_CONSTRUCTIBLE error";
+//    }
+//    if (cameraModel) {
+//       delete cameraModel;
+//    }
+// }
 
 int main(int argc, char **argv) {
    ::testing::InitGoogleTest(&argc, argv);

--- a/tests/data/orbitalSar.json
+++ b/tests/data/orbitalSar.json
@@ -1,5 +1,5 @@
 {
-  "name_model": "USGS_ASTRO_SAR_MODEL",
+  "name_model": "USGS_ASTRO_SAR_SENSOR_MODEL",
   "image_identifier" : "test_sar.img",
   "name_platform": "TEST LUNAR PLATFORM",
   "name_sensor": "TEST SAR",


### PR DESCRIPTION
A lot of this is commented out because not all of the virtual methods are implemented for the SAR model yet. Thus, we can't actually instantiate anything without undefined symbol errors. Once everything is implemented, even just as a stub, then the commented code can be un-commented.