### PR TITLE
Added most of imageToGround

### DIFF
--- a/include/usgscsm/UsgsAstroSarSensorModel.h
+++ b/include/usgscsm/UsgsAstroSarSensorModel.h
@@ -197,6 +197,8 @@ class UsgsAstroSarSensorModel : public csm::RasterGM, virtual public csm::Settab
 
     double slantRangeToGroundRange(const csm::EcefCoord& groundPt, double time, double slantRange, double tolerance) const;
 
+    double groundRangeToSlantRange(double groundRange, const std::vector<double> &coeffs) const;
+
     csm::EcefVector getSpacecraftPosition(double time) const;
     csm::EcefVector getSpacecraftVelocity(double time) const;
     std::vector<double> getRangeCoefficients(double time) const;

--- a/include/usgscsm/Utilities.h
+++ b/include/usgscsm/Utilities.h
@@ -10,6 +10,7 @@
 
 #include <json/json.hpp>
 
+#include <csm.h>
 #include <Warning.h>
 // methods pulled out of los2ecf and computeViewingPixel
 
@@ -83,6 +84,21 @@ double secantRoot(
     std::function<double(double)> func,
     double epsilon = 1e-10,
     int maxIterations = 30);
+
+// Vector operations
+csm::EcefVector operator*(double scalar, const csm::EcefVector &vec);
+csm::EcefVector operator*(const csm::EcefVector &vec, double scalar);
+csm::EcefVector operator/(const csm::EcefVector &vec, double scalar);
+csm::EcefVector operator+(const csm::EcefVector &vec1, const csm::EcefVector &vec2);
+csm::EcefVector operator-(const csm::EcefVector &vec1, const csm::EcefVector &vec2);
+double dot(const csm::EcefVector &vec1, const csm::EcefVector &vec2);
+csm::EcefVector cross(const csm::EcefVector &vec1, const csm::EcefVector &vec2);
+double norm(const csm::EcefVector &vec);
+csm::EcefVector normalized(const csm::EcefVector &vec);
+// The projection of vec1 onto vec2. The component of vec1 that is parallel to vec2
+csm::EcefVector projection(const csm::EcefVector &vec1, const csm::EcefVector &vec2);
+// The rejection of vec1 onto vec2. The component of vec1 that is orthogonal to vec2
+csm::EcefVector rejection(const csm::EcefVector &vec1, const csm::EcefVector &vec2);
 
 // Methods for checking/accessing the ISD
 

--- a/src/Utilities.cpp
+++ b/src/Utilities.cpp
@@ -405,6 +405,74 @@ double secantRoot(double lowerBound, double upperBound, std::function<double(dou
 }
 
 
+csm::EcefVector operator*(double scalar, const csm::EcefVector &vec)
+{
+  return csm::EcefVector(
+      scalar * vec.x,
+      scalar * vec.y,
+      scalar * vec.z);
+}
+
+csm::EcefVector operator*(const csm::EcefVector &vec, double scalar)
+{
+  return scalar * vec;
+}
+
+csm::EcefVector operator/(const csm::EcefVector &vec, double scalar)
+{
+  return 1.0 / scalar * vec;
+}
+
+csm::EcefVector operator+(const csm::EcefVector &vec1, const csm::EcefVector &vec2)
+{
+  return csm::EcefVector(
+      vec1.x + vec2.x,
+      vec1.y + vec2.y,
+      vec1.z + vec2.z);
+}
+
+csm::EcefVector operator-(const csm::EcefVector &vec1, const csm::EcefVector &vec2)
+{
+  return csm::EcefVector(
+      vec1.x - vec2.x,
+      vec1.y - vec2.y,
+      vec1.z - vec2.z);
+}
+
+double dot(const csm::EcefVector &vec1, const csm::EcefVector &vec2)
+{
+  return vec1.x * vec2.x + vec1.y * vec2.y + vec1.z * vec2.z;
+}
+
+csm::EcefVector cross(const csm::EcefVector &vec1, const csm::EcefVector &vec2)
+{
+  return csm::EcefVector(
+      vec1.y * vec2.z - vec1.z * vec2.y,
+      vec1.z * vec2.x - vec1.x * vec2.z,
+      vec1.x * vec2.y - vec1.y * vec2.x);
+}
+
+double norm(const csm::EcefVector &vec)
+{
+  return sqrt(vec.x * vec.x + vec.y * vec.y + vec.z * vec.z);
+}
+
+csm::EcefVector normalized(const csm::EcefVector &vec)
+{
+  return vec / norm(vec);
+}
+
+csm::EcefVector projection(const csm::EcefVector &vec1, const csm::EcefVector &vec2)
+{
+  return dot(vec1, vec2) / dot(vec2, vec2) * vec2;
+}
+
+csm::EcefVector rejection(const csm::EcefVector &vec1, const csm::EcefVector &vec2)
+{
+  return vec1 - projection(vec1, vec2);
+}
+
+
 // convert a measurement
 double metric_conversion(double val, std::string from, std::string to) {
     json typemap = {

--- a/tests/SarTests.cpp
+++ b/tests/SarTests.cpp
@@ -44,11 +44,12 @@ TEST_F(SarSensorModel, State) {
 }
 
 TEST_F(SarSensorModel, Center) {
-  csm::ImageCoord imagePt(7.5, 7.5);
+  csm::ImageCoord imagePt(500.0, 500.0);
   csm::EcefCoord groundPt = sensorModel->imageToGround(imagePt, 0.0);
-  EXPECT_NEAR(groundPt.x, 0, 1e-8);
-  EXPECT_NEAR(groundPt.y, 0, 1e-8);
-  EXPECT_NEAR(groundPt.z, 0, 1e-8);
+  // TODO these tolerances are bad
+  EXPECT_NEAR(groundPt.x, 1737391.90602155, 1e-2);
+  EXPECT_NEAR(groundPt.y, 3749.98835331, 1e-2);
+  EXPECT_NEAR(groundPt.z, -3749.99708833, 1e-2);
 }
 
 TEST_F(SarSensorModel, GroundToImage) {

--- a/tests/UtilitiesTests.cpp
+++ b/tests/UtilitiesTests.cpp
@@ -358,3 +358,137 @@ TEST(UtilitiesTests, secantRoot) {
   EXPECT_NEAR(secantRoot(0.0, -3.0, testPoly, 1e-10), -1.0, 1e-10);
   EXPECT_THROW(secantRoot(-1000.0, 1000.0, testPoly), csm::Error);
 }
+
+TEST(UtilitiesTests, vectorProduct) {
+  csm::EcefVector vec(1.0, 2.0, 3.0);
+  csm::EcefVector leftVec = 2.0 * vec;
+  csm::EcefVector rightVec = vec * 2;
+  EXPECT_DOUBLE_EQ(leftVec.x, 2.0);
+  EXPECT_DOUBLE_EQ(leftVec.y, 4.0);
+  EXPECT_DOUBLE_EQ(leftVec.z, 6.0);
+  EXPECT_DOUBLE_EQ(rightVec.x, 2.0);
+  EXPECT_DOUBLE_EQ(rightVec.y, 4.0);
+  EXPECT_DOUBLE_EQ(rightVec.z, 6.0);
+}
+
+TEST(UtilitiesTests, vectorDivision) {
+  csm::EcefVector vec(2.0, 4.0, 6.0);
+  csm::EcefVector divVec = vec / 2.0;
+  EXPECT_DOUBLE_EQ(divVec.x, 1.0);
+  EXPECT_DOUBLE_EQ(divVec.y, 2.0);
+  EXPECT_DOUBLE_EQ(divVec.z, 3.0);
+}
+
+TEST(UtilitiesTests, vectorAddition) {
+  csm::EcefVector vec1(2.0, 4.0, 6.0);
+  csm::EcefVector vec2(1.0, 2.0, 3.0);
+  csm::EcefVector sumVec = vec1 + vec2;
+  EXPECT_DOUBLE_EQ(sumVec.x, 3.0);
+  EXPECT_DOUBLE_EQ(sumVec.y, 6.0);
+  EXPECT_DOUBLE_EQ(sumVec.z, 9.0);
+}
+
+TEST(UtilitiesTests, vectorSubtraction) {
+  csm::EcefVector vec1(2.0, 4.0, 6.0);
+  csm::EcefVector vec2(1.0, 2.0, 3.0);
+  csm::EcefVector diffVec = vec1 - vec2;
+  EXPECT_DOUBLE_EQ(diffVec.x, 1.0);
+  EXPECT_DOUBLE_EQ(diffVec.y, 2.0);
+  EXPECT_DOUBLE_EQ(diffVec.z, 3.0);
+}
+
+TEST(UtilitiesTests, vectorDot) {
+  csm::EcefVector unitX(1.0, 0.0, 0.0);
+  csm::EcefVector unitY(0.0, 1.0, 0.0);
+  csm::EcefVector unitZ(0.0, 0.0, 1.0);
+  csm::EcefVector testVec(1.0, 2.0, 3.0);
+  EXPECT_DOUBLE_EQ(dot(testVec, unitX), 1.0);
+  EXPECT_DOUBLE_EQ(dot(testVec, unitY), 2.0);
+  EXPECT_DOUBLE_EQ(dot(testVec, unitZ), 3.0);
+}
+
+TEST(UtilitiesTests, vectorCross) {
+  csm::EcefVector unitX(1.0, 0.0, 0.0);
+  csm::EcefVector unitY(0.0, 1.0, 0.0);
+  csm::EcefVector unitZ(0.0, 0.0, 1.0);
+
+  csm::EcefVector unitXY = cross(unitX, unitY);
+  EXPECT_DOUBLE_EQ(unitXY.x, 0.0);
+  EXPECT_DOUBLE_EQ(unitXY.y, 0.0);
+  EXPECT_DOUBLE_EQ(unitXY.z, 1.0);
+
+
+  csm::EcefVector unitYX = cross(unitY, unitX);
+  EXPECT_DOUBLE_EQ(unitYX.x, 0.0);
+  EXPECT_DOUBLE_EQ(unitYX.y, 0.0);
+  EXPECT_DOUBLE_EQ(unitYX.z, -1.0);
+
+  csm::EcefVector unitXZ = cross(unitX, unitZ);
+  EXPECT_DOUBLE_EQ(unitXZ.x, 0.0);
+  EXPECT_DOUBLE_EQ(unitXZ.y, -1.0);
+  EXPECT_DOUBLE_EQ(unitXZ.z, 0.0);
+
+
+  csm::EcefVector unitZX = cross(unitZ, unitX);
+  EXPECT_DOUBLE_EQ(unitZX.x, 0.0);
+  EXPECT_DOUBLE_EQ(unitZX.y, 1.0);
+  EXPECT_DOUBLE_EQ(unitZX.z, 0.0);
+
+  csm::EcefVector unitYZ = cross(unitY, unitZ);
+  EXPECT_DOUBLE_EQ(unitYZ.x, 1.0);
+  EXPECT_DOUBLE_EQ(unitYZ.y, 0.0);
+  EXPECT_DOUBLE_EQ(unitYZ.z, 0.0);
+
+
+  csm::EcefVector unitZY = cross(unitZ, unitY);
+  EXPECT_DOUBLE_EQ(unitZY.x, -1.0);
+  EXPECT_DOUBLE_EQ(unitZY.y, 0.0);
+  EXPECT_DOUBLE_EQ(unitZY.z, 0.0);
+}
+
+TEST(UtilitiesTests, vectorNorm) {
+  csm::EcefVector testVec(1.0, 2.0, 3.0);
+  EXPECT_DOUBLE_EQ(norm(testVec), sqrt(14.0));
+  csm::EcefVector normVec = normalized(testVec);
+  EXPECT_DOUBLE_EQ(normVec.x, 1.0 / sqrt(14.0));
+  EXPECT_DOUBLE_EQ(normVec.y, 2.0 / sqrt(14.0));
+  EXPECT_DOUBLE_EQ(normVec.z, 3.0 / sqrt(14.0));
+}
+
+TEST(UtilitiesTests, vectorProjection) {
+  csm::EcefVector unitX(1.0, 0.0, 0.0);
+  csm::EcefVector unitY(0.0, 1.0, 0.0);
+  csm::EcefVector unitZ(0.0, 0.0, 1.0);
+
+  csm::EcefVector testVec(1.0, 2.0, 3.0);
+
+  csm::EcefVector projX = projection(testVec, unitX);
+  EXPECT_DOUBLE_EQ(projX.x, 1.0);
+  EXPECT_DOUBLE_EQ(projX.y, 0.0);
+  EXPECT_DOUBLE_EQ(projX.z, 0.0);
+
+  csm::EcefVector rejectX = rejection(testVec, unitX);
+  EXPECT_DOUBLE_EQ(rejectX.x, 0.0);
+  EXPECT_DOUBLE_EQ(rejectX.y, 2.0);
+  EXPECT_DOUBLE_EQ(rejectX.z, 3.0);
+
+  csm::EcefVector projY = projection(testVec, unitY);
+  EXPECT_DOUBLE_EQ(projY.x, 0.0);
+  EXPECT_DOUBLE_EQ(projY.y, 2.0);
+  EXPECT_DOUBLE_EQ(projY.z, 0.0);
+
+  csm::EcefVector rejectY = rejection(testVec, unitY);
+  EXPECT_DOUBLE_EQ(rejectY.x, 1.0);
+  EXPECT_DOUBLE_EQ(rejectY.y, 0.0);
+  EXPECT_DOUBLE_EQ(rejectY.z, 3.0);
+
+  csm::EcefVector projZ = projection(testVec, unitZ);
+  EXPECT_DOUBLE_EQ(projZ.x, 0.0);
+  EXPECT_DOUBLE_EQ(projZ.y, 0.0);
+  EXPECT_DOUBLE_EQ(projZ.z, 3.0);
+
+  csm::EcefVector rejectZ = rejection(testVec, unitZ);
+  EXPECT_DOUBLE_EQ(rejectZ.x, 1.0);
+  EXPECT_DOUBLE_EQ(rejectZ.y, 2.0);
+  EXPECT_DOUBLE_EQ(rejectZ.z, 0.0);
+}


### PR DESCRIPTION
This handles most of the math involved in image to ground. There are a few things still missing here:

1. the left/right look is waiting on #283 
1. This only does a sphere
1. The test image result is only accurate to within a handful of millimeters

There are also a handful of nice to have things that aren't in here:

1. ~Proper vector math operators with ecefVectors and ecefCoords~
1. Separate methods that compute the circle of points at the proper range.