### PR TITLE
Logging Update

### DIFF
--- a/include/usgscsm/UsgsAstroFrameSensorModel.h
+++ b/include/usgscsm/UsgsAstroFrameSensorModel.h
@@ -322,7 +322,7 @@ class UsgsAstroFrameSensorModel : public csm::RasterGM, virtual public csm::Sett
         const GeometricModel &comparisonModel,
         csm::param::Set pSet = csm::param::VALID,
         const GeometricModelList &otherModels = GeometricModelList()) const;
-    virtual std::string getLogger();
+    virtual std::shared_ptr<spdlog::logger> getLogger();
     virtual void setLogger(std::string logName);
     double getValue(int index, const std::vector<double> &adjustments) const;
     void calcRotationMatrix(double m[3][3]) const;
@@ -384,7 +384,7 @@ class UsgsAstroFrameSensorModel : public csm::RasterGM, virtual public csm::Sett
 
     csm::EcefCoord m_referencePointXyz;
 
-    std::string m_logName = "usgscsm_logger";
+    std::shared_ptr<spdlog::logger> m_logger = spdlog::get("usgscsm_logger");
 
     json _state;
     static const int         _NUM_STATE_KEYWORDS;

--- a/include/usgscsm/UsgsAstroFrameSensorModel.h
+++ b/include/usgscsm/UsgsAstroFrameSensorModel.h
@@ -384,7 +384,7 @@ class UsgsAstroFrameSensorModel : public csm::RasterGM, virtual public csm::Sett
 
     csm::EcefCoord m_referencePointXyz;
 
-    std::string m_logName;
+    std::string m_logName = "";
 
     json _state;
     static const int         _NUM_STATE_KEYWORDS;

--- a/include/usgscsm/UsgsAstroFrameSensorModel.h
+++ b/include/usgscsm/UsgsAstroFrameSensorModel.h
@@ -384,7 +384,7 @@ class UsgsAstroFrameSensorModel : public csm::RasterGM, virtual public csm::Sett
 
     csm::EcefCoord m_referencePointXyz;
 
-    std::string m_logName = "";
+    std::string m_logName = "usgscsm_logger";
 
     json _state;
     static const int         _NUM_STATE_KEYWORDS;

--- a/include/usgscsm/UsgsAstroFrameSensorModel.h
+++ b/include/usgscsm/UsgsAstroFrameSensorModel.h
@@ -12,7 +12,6 @@
 #include "Utilities.h"
 
 #include "spdlog/spdlog.h"
-#include "spdlog/sinks/basic_file_sink.h"
 
 #include <json/json.hpp>
 
@@ -323,8 +322,8 @@ class UsgsAstroFrameSensorModel : public csm::RasterGM, virtual public csm::Sett
         const GeometricModel &comparisonModel,
         csm::param::Set pSet = csm::param::VALID,
         const GeometricModelList &otherModels = GeometricModelList()) const;
-    virtual std::shared_ptr<spdlog::logger> getLogger();
-    virtual void setLogger(std::shared_ptr<spdlog::logger> logger);
+    virtual std::string getLogger();
+    virtual void setLogger(std::string logName);
     double getValue(int index, const std::vector<double> &adjustments) const;
     void calcRotationMatrix(double m[3][3]) const;
     void calcRotationMatrix(double m[3][3], const std::vector<double> &adjustments) const;
@@ -385,8 +384,7 @@ class UsgsAstroFrameSensorModel : public csm::RasterGM, virtual public csm::Sett
 
     csm::EcefCoord m_referencePointXyz;
 
-    std::string m_logFile;
-    std::shared_ptr<spdlog::logger> m_logger;
+    std::string m_logName;
 
     json _state;
     static const int         _NUM_STATE_KEYWORDS;

--- a/include/usgscsm/UsgsAstroLsSensorModel.h
+++ b/include/usgscsm/UsgsAstroLsSensorModel.h
@@ -33,7 +33,6 @@
 #include "Distortion.h"
 
 #include "spdlog/spdlog.h"
-#include "spdlog/sinks/basic_file_sink.h"
 
 class UsgsAstroLsSensorModel : public csm::RasterGM, virtual public csm::SettableEllipsoid
 {
@@ -64,7 +63,7 @@ public:
    static std::string getModelNameFromModelState(
       const std::string& model_state);
 
-  std::string constructStateFromIsd(const std::string imageSupportData, csm::WarningList *list) const;
+  std::string constructStateFromIsd(const std::string imageSupportData, csm::WarningList *list);
 
    // State data elements;
    std::string  m_imageIdentifier;
@@ -125,8 +124,7 @@ public:
 
 
    // Define logging pointer and file content
-   std::string m_logFile;
-   std::shared_ptr<spdlog::logger> m_logger;
+   std::string m_logName = "usgscsm_logger";
 
    // Hardcoded
    static const std::string      _SENSOR_MODEL_NAME; // state date element 0
@@ -696,8 +694,8 @@ public:
    //  reference by the given index.
    //<
 
-   virtual std::shared_ptr<spdlog::logger> getLogger();
-   virtual void setLogger(std::shared_ptr<spdlog::logger> logger);
+   virtual std::string getLogger();
+   virtual void setLogger(std::string logName);
 
 
    //---

--- a/include/usgscsm/UsgsAstroLsSensorModel.h
+++ b/include/usgscsm/UsgsAstroLsSensorModel.h
@@ -124,7 +124,7 @@ public:
 
 
    // Define logging pointer and file content
-   std::string m_logName = "usgscsm_logger";
+   std::shared_ptr<spdlog::logger> m_logger = spdlog::get("usgscsm_logger");
 
    // Hardcoded
    static const std::string      _SENSOR_MODEL_NAME; // state date element 0
@@ -694,7 +694,7 @@ public:
    //  reference by the given index.
    //<
 
-   virtual std::string getLogger();
+   virtual std::shared_ptr<spdlog::logger> getLogger();
    virtual void setLogger(std::string logName);
 
 

--- a/include/usgscsm/UsgsAstroPlugin.h
+++ b/include/usgscsm/UsgsAstroPlugin.h
@@ -10,7 +10,7 @@
 #include "spdlog/spdlog.h"
 #include "spdlog/sinks/basic_file_sink.h"
 
-#include <nlohmann/json.hpp>
+#include <json/json.hpp>
 using json = nlohmann::json;
 
 class UsgsAstroPlugin : public csm::Plugin {

--- a/include/usgscsm/UsgsAstroPlugin.h
+++ b/include/usgscsm/UsgsAstroPlugin.h
@@ -7,7 +7,10 @@
 #include <Plugin.h>
 #include <Version.h>
 
-#include <json/json.hpp>
+#include "spdlog/spdlog.h"
+#include "spdlog/sinks/basic_file_sink.h"
+
+#include <nlohmann/json.hpp>
 using json = nlohmann::json;
 
 class UsgsAstroPlugin : public csm::Plugin {

--- a/src/UsgsAstroFrameSensorModel.cpp
+++ b/src/UsgsAstroFrameSensorModel.cpp
@@ -874,7 +874,7 @@ std::string UsgsAstroFrameSensorModel::constructStateFromIsd(const std::string& 
     }
 
     MESSAGE_LOG("Constructing state from isd");
-    ale::Isd stateIsd(jsonIsd);
+    json isd = json::parse(jsonIsd);
 
     csm::WarningList* parsingWarnings = new csm::WarningList;
 

--- a/src/UsgsAstroFrameSensorModel.cpp
+++ b/src/UsgsAstroFrameSensorModel.cpp
@@ -9,7 +9,7 @@
 #include <Error.h>
 #include <Version.h>
 
-#define MESSAGE_LOG(logger, ...) if (logger) { logger->info(__VA_ARGS__); }
+#define MESSAGE_LOG(...) if (spdlog::get(m_logName)) { spdlog::get(m_logName)->info(__VA_ARGS__); }
 
 using json = nlohmann::json;
 using namespace std;
@@ -77,8 +77,7 @@ void UsgsAstroFrameSensorModel::reset() {
     m_referencePointXyz.x = 0;
     m_referencePointXyz.y = 0;
     m_referencePointXyz.z = 0;
-    m_logFile = "";
-    m_logger.reset();
+    m_logName = "usgscsm_logger";
 }
 
 
@@ -97,7 +96,7 @@ csm::ImageCoord UsgsAstroFrameSensorModel::groundToImage(const csm::EcefCoord &g
                               double desiredPrecision,
                               double *achievedPrecision,
                               csm::WarningList *warnings) const {
-  MESSAGE_LOG(this->m_logger, "Computing groundToImage(No adjustments) for {}, {}, {}, with desired precision {}",
+  MESSAGE_LOG("Computing groundToImage(No adjustments) for {}, {}, {}, with desired precision {}",
               groundPt.x, groundPt.y, groundPt.z, desiredPrecision);
 
   return groundToImage(groundPt, m_noAdjustments, desiredPrecision, achievedPrecision, warnings);
@@ -121,7 +120,7 @@ csm::ImageCoord UsgsAstroFrameSensorModel::groundToImage(
     double*                    achieved_precision,
     csm::WarningList*          warnings ) const {
 
-  MESSAGE_LOG(this->m_logger, "Computing groundToImage for {}, {}, {}, with desired precision {}",
+  MESSAGE_LOG("Computing groundToImage for {}, {}, {}, with desired precision {}",
               groundPt.x, groundPt.y, groundPt.z, desired_precision);
 
   double x = groundPt.x;
@@ -169,7 +168,7 @@ csm::ImageCoordCovar UsgsAstroFrameSensorModel::groundToImage(const csm::EcefCoo
                                    double desiredPrecision,
                                    double *achievedPrecision,
                                    csm::WarningList *warnings) const {
-    MESSAGE_LOG(this->m_logger, "Computeing groundToImage(Covar) for {}, {}, {}, with desired precision {}",
+    MESSAGE_LOG("Computeing groundToImage(Covar) for {}, {}, {}, with desired precision {}",
                 groundPt.x, groundPt.y, groundPt.z, desiredPrecision);
 
     csm::EcefCoord gp;
@@ -192,7 +191,7 @@ csm::EcefCoord UsgsAstroFrameSensorModel::imageToGround(const csm::ImageCoord &i
                                                  double *achievedPrecision,
                                                  csm::WarningList *warnings) const {
 
-  MESSAGE_LOG(this->m_logger, "Computing imageToGround for {}, {}, {}, with desired precision {}",
+  MESSAGE_LOG("Computing imageToGround for {}, {}, {}, with desired precision {}",
                 imagePt.line, imagePt.samp, height, desiredPrecision);
 
   double sample = imagePt.samp;
@@ -201,7 +200,7 @@ csm::EcefCoord UsgsAstroFrameSensorModel::imageToGround(const csm::ImageCoord &i
   // Here is where we should be able to apply an adjustment to opk
   double m[3][3];
   calcRotationMatrix(m);
-  MESSAGE_LOG(this->m_logger, "Calculated rotation matrix [{}, {}, {}], [{}, {}, {}], [{}, {}, {}]",
+  MESSAGE_LOG("Calculated rotation matrix [{}, {}, {}], [{}, {}, {}], [{}, {}, {}]",
                 m[0][0], m[0][1], m[0][2], m[1][0], m[1][1], m[1][2], m[2][0], m[2][1], m[2][2]);
 
   // Apply the principal point offset, assuming the pp is given in pixels
@@ -222,20 +221,20 @@ csm::EcefCoord UsgsAstroFrameSensorModel::imageToGround(const csm::ImageCoord &i
   removeDistortion(x_camera, y_camera, undistortedX, undistortedY,
                    m_opticalDistCoeffs,
                    m_distortionType);
-  MESSAGE_LOG(this->m_logger, "Found undistortedX: {}, and undistortedY: {}",
+  MESSAGE_LOG("Found undistortedX: {}, and undistortedY: {}",
                                undistortedX, undistortedY);
 
   // Now back from distorted mm to pixels
   xl = m[0][0] * undistortedX + m[0][1] * undistortedY - m[0][2] * - m_focalLength;
   yl = m[1][0] * undistortedX + m[1][1] * undistortedY - m[1][2] * - m_focalLength;
   zl = m[2][0] * undistortedX + m[2][1] * undistortedY - m[2][2] * - m_focalLength;
-  MESSAGE_LOG(this->m_logger, "Compute xl, yl, zl as {}, {}, {}", xl, yl, zl);
+  MESSAGE_LOG("Compute xl, yl, zl as {}, {}, {}", xl, yl, zl);
 
   double xc, yc, zc;
   xc = m_currentParameterValue[0];
   yc = m_currentParameterValue[1];
   zc = m_currentParameterValue[2];
-  MESSAGE_LOG(this->m_logger, "Set xc, yc, zc to {}, {}, {}",
+  MESSAGE_LOG("Set xc, yc, zc to {}, {}, {}",
                               m_currentParameterValue[0], m_currentParameterValue[1], m_currentParameterValue[2]);
 
   // Intersect with some height about the ellipsoid.
@@ -251,7 +250,7 @@ csm::EcefCoordCovar UsgsAstroFrameSensorModel::imageToGround(const csm::ImageCoo
                                   double *achievedPrecision,
                                   csm::WarningList *warnings) const {
 
-    MESSAGE_LOG(this->m_logger, "Computeing imageToGround(Covar) for {}, {}, {}, with desired precision {}",
+    MESSAGE_LOG("Computeing imageToGround(Covar) for {}, {}, {}, with desired precision {}",
                 imagePt.line, imagePt.samp, height, desiredPrecision);
     // This is an incomplete implementation to see if SocetGXP needs this method implemented.
     csm::EcefCoordCovar result;
@@ -265,7 +264,7 @@ csm::EcefLocus UsgsAstroFrameSensorModel::imageToProximateImagingLocus(const csm
                                                                 double *achievedPrecision,
                                                                 csm::WarningList *warnings) const {
   // Ignore the ground point?
-  MESSAGE_LOG(this->m_logger, "Computeing imageToProximateImagingLocus(No ground) for point {}, {}, {}, with desired precision {}",
+  MESSAGE_LOG("Computeing imageToProximateImagingLocus(No ground) for point {}, {}, {}, with desired precision {}",
                                imagePt.line, imagePt.samp, desiredPrecision);
   return imageToRemoteImagingLocus(imagePt);
 }
@@ -275,7 +274,7 @@ csm::EcefLocus UsgsAstroFrameSensorModel::imageToRemoteImagingLocus(const csm::I
                                                              double desiredPrecision,
                                                              double *achievedPrecision,
                                                              csm::WarningList *warnings) const {
-  MESSAGE_LOG(this->m_logger, "Computeing imageToProximateImagingLocus for {}, {}, {}, with desired precision {}",
+  MESSAGE_LOG("Computeing imageToProximateImagingLocus for {}, {}, {}, with desired precision {}",
                                imagePt.line, imagePt.samp, desiredPrecision);
   // Find the line,sample on the focal plane (mm)
   double focalPlaneX, focalPlaneY;
@@ -319,7 +318,7 @@ csm::EcefLocus UsgsAstroFrameSensorModel::imageToRemoteImagingLocus(const csm::I
 
 csm::ImageCoord UsgsAstroFrameSensorModel::getImageStart() const {
 
-  MESSAGE_LOG(this->m_logger, "Accessing Image Start line: {}, sample: {}",
+  MESSAGE_LOG("Accessing Image Start line: {}, sample: {}",
                               m_startingDetectorLine, m_startingDetectorSample);
   csm::ImageCoord start;
   start.samp = m_startingDetectorSample;
@@ -330,7 +329,7 @@ csm::ImageCoord UsgsAstroFrameSensorModel::getImageStart() const {
 
 csm::ImageVector UsgsAstroFrameSensorModel::getImageSize() const {
 
-  MESSAGE_LOG(this->m_logger, "Accessing Image Size line: {}, sample: {}",
+  MESSAGE_LOG("Accessing Image Size line: {}, sample: {}",
                               m_nLines, m_nSamples);
   csm::ImageVector size;
   size.line = m_nLines;
@@ -340,7 +339,7 @@ csm::ImageVector UsgsAstroFrameSensorModel::getImageSize() const {
 
 
 std::pair<csm::ImageCoord, csm::ImageCoord> UsgsAstroFrameSensorModel::getValidImageRange() const {
-    MESSAGE_LOG(this->m_logger, "Accessing Image Range");
+    MESSAGE_LOG("Accessing Image Range");
     csm::ImageCoord min_pt(m_startingDetectorLine, m_startingDetectorSample);
     csm::ImageCoord max_pt(m_nLines, m_nSamples);
     return std::pair<csm::ImageCoord, csm::ImageCoord>(min_pt, max_pt);
@@ -348,7 +347,7 @@ std::pair<csm::ImageCoord, csm::ImageCoord> UsgsAstroFrameSensorModel::getValidI
 
 
 std::pair<double, double> UsgsAstroFrameSensorModel::getValidHeightRange() const {
-    MESSAGE_LOG(this->m_logger, "Accessing Image Height min: {}, max: {}",
+    MESSAGE_LOG("Accessing Image Height min: {}, max: {}",
                                 m_minElevation, m_maxElevation);
     return std::pair<double, double>(m_minElevation, m_maxElevation);
 }
@@ -356,7 +355,7 @@ std::pair<double, double> UsgsAstroFrameSensorModel::getValidHeightRange() const
 
 csm::EcefVector UsgsAstroFrameSensorModel::getIlluminationDirection(const csm::EcefCoord &groundPt) const {
   // ground (body-fixed) - sun (body-fixed) gives us the illumination direction.
-  MESSAGE_LOG(this->m_logger, "Accessing illumination direction for ground point {}, {}, {}",
+  MESSAGE_LOG("Accessing illumination direction for ground point {}, {}, {}",
               groundPt.x, groundPt.y, groundPt.z);
   return csm::EcefVector {
     groundPt.x - m_sunPosition[0],
@@ -367,14 +366,14 @@ csm::EcefVector UsgsAstroFrameSensorModel::getIlluminationDirection(const csm::E
 
 
 double UsgsAstroFrameSensorModel::getImageTime(const csm::ImageCoord &imagePt) const {
-  MESSAGE_LOG(this->m_logger, "Accessing image time for image point {}, {}",
+  MESSAGE_LOG("Accessing image time for image point {}, {}",
               imagePt.line, imagePt.samp);
     return m_ephemerisTime;
 }
 
 
 csm::EcefCoord UsgsAstroFrameSensorModel::getSensorPosition(const csm::ImageCoord &imagePt) const {
-  MESSAGE_LOG(this->m_logger, "Accessing sensor position for image point {}, {}",
+  MESSAGE_LOG("Accessing sensor position for image point {}, {}",
               imagePt.line, imagePt.samp);
   // check if the image point is in range
   if (imagePt.samp >= m_startingDetectorSample &&
@@ -397,7 +396,7 @@ csm::EcefCoord UsgsAstroFrameSensorModel::getSensorPosition(const csm::ImageCoor
 
 
 csm::EcefCoord UsgsAstroFrameSensorModel::getSensorPosition(double time) const {
-    MESSAGE_LOG(this->m_logger, "Accessing sensor position for time {}", time);
+    MESSAGE_LOG("Accessing sensor position for time {}", time);
     if (time == m_ephemerisTime){
         csm::EcefCoord sensorPosition;
         sensorPosition.x = m_currentParameterValue[0];
@@ -415,7 +414,7 @@ csm::EcefCoord UsgsAstroFrameSensorModel::getSensorPosition(double time) const {
 
 
 csm::EcefVector UsgsAstroFrameSensorModel::getSensorVelocity(const csm::ImageCoord &imagePt) const {
-  MESSAGE_LOG(this->m_logger, "Accessing sensor velocity for image point {}, {}",
+  MESSAGE_LOG("Accessing sensor velocity for image point {}, {}",
               imagePt.line, imagePt.samp);
   // Make sure the passed coordinate is with the image dimensions.
   if (imagePt.samp < 0.0 || imagePt.samp > m_nSamples ||
@@ -434,7 +433,7 @@ csm::EcefVector UsgsAstroFrameSensorModel::getSensorVelocity(const csm::ImageCoo
 
 
 csm::EcefVector UsgsAstroFrameSensorModel::getSensorVelocity(double time) const {
-    MESSAGE_LOG(this->m_logger, "Accessing sensor position for time {}", time);
+    MESSAGE_LOG("Accessing sensor position for time {}", time);
     if (time == m_ephemerisTime){
         return csm::EcefVector {
           m_spacecraftVelocity[0],
@@ -455,7 +454,7 @@ csm::RasterGM::SensorPartials UsgsAstroFrameSensorModel::computeSensorPartials(i
                                            double desiredPrecision,
                                            double *achievedPrecision,
                                            csm::WarningList *warnings) const {
-    MESSAGE_LOG(this->m_logger, "Computing sensor partials image point from ground point {}, {}, {} \
+    MESSAGE_LOG("Computing sensor partials image point from ground point {}, {}, {} \
                                  and desiredPrecision: {}", groundPt.x, groundPt.y, groundPt.z, desiredPrecision);
 
     csm::ImageCoord img_pt = groundToImage(groundPt, desiredPrecision, achievedPrecision);
@@ -485,7 +484,7 @@ csm::RasterGM::SensorPartials UsgsAstroFrameSensorModel::computeSensorPartials(i
                                           double *achievedPrecision,
                                           csm::WarningList *warnings) const {
 
-  MESSAGE_LOG(this->m_logger, "Computing sensor partials for ground point {}, {}, {}\
+  MESSAGE_LOG("Computing sensor partials for ground point {}, {}, {}\
                                with point: {}, {}, index: {}, and desiredPrecision: {}",
                                groundPt.x, groundPt.y, groundPt.z, imagePt.line, imagePt.samp,
                                index, desiredPrecision);
@@ -518,7 +517,7 @@ std::vector<csm::RasterGM::SensorPartials> UsgsAstroFrameSensorModel::computeAll
     double desiredPrecision,
     double *achievedPrecision,
     csm::WarningList *warnings) const {
-  MESSAGE_LOG(this->m_logger, "Computing all sensor partials for ground point {}, {}, {}\
+  MESSAGE_LOG("Computing all sensor partials for ground point {}, {}, {}\
                                with point: {}, {}, pset: {}, and desiredPrecision: {}",
                                groundPt.x, groundPt.y, groundPt.z, imagePt.line, imagePt.samp,
                                pset, desiredPrecision);
@@ -540,7 +539,7 @@ std::vector<csm::RasterGM::SensorPartials> UsgsAstroFrameSensorModel::computeAll
     double desiredPrecision,
     double *achievedPrecision,
     csm::WarningList *warnings) const {
-  MESSAGE_LOG(this->m_logger, "Computing all sensor partials image point from ground point {}, {}, {} \
+  MESSAGE_LOG("Computing all sensor partials image point from ground point {}, {}, {} \
                                and desiredPrecision: {}", groundPt.x, groundPt.y, groundPt.z, desiredPrecision);
   csm::ImageCoord imagePt = groundToImage(groundPt,
                                           desiredPrecision, achievedPrecision, warnings);
@@ -550,7 +549,7 @@ std::vector<csm::RasterGM::SensorPartials> UsgsAstroFrameSensorModel::computeAll
 
 std::vector<double> UsgsAstroFrameSensorModel::computeGroundPartials(const csm::EcefCoord
                                                                      &groundPt) const {
-  MESSAGE_LOG(this->m_logger, "Computing ground partials for ground point {}, {}, {}",
+  MESSAGE_LOG("Computing ground partials for ground point {}, {}, {}",
                                groundPt.x, groundPt.y, groundPt.z);
   // Partial of line, sample wrt X, Y, Z
   double x = groundPt.x;
@@ -585,7 +584,7 @@ std::vector<double> UsgsAstroFrameSensorModel::computeGroundPartials(const csm::
   partials[2] = (ipZ.line - ipB.line) / pixelGroundSize;
   partials[5] = (ipZ.samp - ipB.samp) / pixelGroundSize;
 
-  MESSAGE_LOG(this->m_logger, "Computing ground partials results:\nLine: {}, {}, {}\nSample: {}, {}, {}",
+  MESSAGE_LOG("Computing ground partials results:\nLine: {}, {}, {}\nSample: {}, {}, {}",
                                partials[0], partials[1], partials[2], partials[3], partials[4], partials[5]);
 
   return partials;
@@ -593,7 +592,7 @@ std::vector<double> UsgsAstroFrameSensorModel::computeGroundPartials(const csm::
 
 
 const csm::CorrelationModel& UsgsAstroFrameSensorModel::getCorrelationModel() const {
-  MESSAGE_LOG(this->m_logger, "Accessing correlation model");
+  MESSAGE_LOG("Accessing correlation model");
   return _no_corr_model;
 }
 
@@ -602,7 +601,7 @@ std::vector<double> UsgsAstroFrameSensorModel::getUnmodeledCrossCovariance(const
                                                 const csm::ImageCoord &pt2) const {
 
    // No unmodeled error
-   MESSAGE_LOG(this->m_logger, "Accessing unmodeled cross covar with \
+   MESSAGE_LOG("Accessing unmodeled cross covar with \
                                 point1: {}, {} and point2: {}, {}",
                                 pt1.line, pt1.samp, pt2.line, pt2.samp);
    return std::vector<double>(4, 0.0);
@@ -610,74 +609,74 @@ std::vector<double> UsgsAstroFrameSensorModel::getUnmodeledCrossCovariance(const
 
 
 csm::Version UsgsAstroFrameSensorModel::getVersion() const {
-  MESSAGE_LOG(this->m_logger, "Accessing CSM version");
+  MESSAGE_LOG("Accessing CSM version");
   return csm::Version(0,1,0);
 }
 
 
 std::string UsgsAstroFrameSensorModel::getModelName() const {
-  MESSAGE_LOG(this->m_logger, "Accessing CSM name {}", _SENSOR_MODEL_NAME);
+  MESSAGE_LOG("Accessing CSM name {}", _SENSOR_MODEL_NAME);
   return _SENSOR_MODEL_NAME;
 }
 
 
 std::string UsgsAstroFrameSensorModel::getPedigree() const {
-  MESSAGE_LOG(this->m_logger, "Accessing CSM pedigree");
+  MESSAGE_LOG("Accessing CSM pedigree");
   return "USGS_FRAMER";
 }
 
 
 std::string UsgsAstroFrameSensorModel::getImageIdentifier() const {
-  MESSAGE_LOG(this->m_logger, "Accessing image ID {}", m_imageIdentifier);
+  MESSAGE_LOG("Accessing image ID {}", m_imageIdentifier);
   return m_imageIdentifier;
 }
 
 
 void UsgsAstroFrameSensorModel::setImageIdentifier(const std::string& imageId,
                                             csm::WarningList* warnings) {
-  MESSAGE_LOG(this->m_logger, "Setting image ID to {}", imageId);
+  MESSAGE_LOG("Setting image ID to {}", imageId);
   m_imageIdentifier = imageId;
 }
 
 
 std::string UsgsAstroFrameSensorModel::getSensorIdentifier() const {
-  MESSAGE_LOG(this->m_logger, "Accessing sensor ID");
+  MESSAGE_LOG("Accessing sensor ID");
   return m_sensorName;
 }
 
 
 std::string UsgsAstroFrameSensorModel::getPlatformIdentifier() const {
-  MESSAGE_LOG(this->m_logger, "Accessing platform ID");
+  MESSAGE_LOG("Accessing platform ID");
   return m_platformName;
 }
 
 
 std::string UsgsAstroFrameSensorModel::getCollectionIdentifier() const {
-  MESSAGE_LOG(this->m_logger, "Accessing collection ID");
+  MESSAGE_LOG("Accessing collection ID");
   return m_collectionIdentifier;
 }
 
 
 std::string UsgsAstroFrameSensorModel::getTrajectoryIdentifier() const {
-  MESSAGE_LOG(this->m_logger, "Accessing trajectory ID");
+  MESSAGE_LOG("Accessing trajectory ID");
   return "";
 }
 
 
 std::string UsgsAstroFrameSensorModel::getSensorType() const {
-    MESSAGE_LOG(this->m_logger, "Accessing sensor type");
+    MESSAGE_LOG("Accessing sensor type");
     return CSM_SENSOR_TYPE_EO;
 }
 
 
 std::string UsgsAstroFrameSensorModel::getSensorMode() const {
-    MESSAGE_LOG(this->m_logger, "Accessing sensor mode");
+    MESSAGE_LOG("Accessing sensor mode");
     return CSM_SENSOR_MODE_FRAME;
 }
 
 
 std::string UsgsAstroFrameSensorModel::getReferenceDateAndTime() const {
-  MESSAGE_LOG(this->m_logger, "Accessing reference data and time");
+  MESSAGE_LOG("Accessing reference data and time");
   csm::EcefCoord referencePointGround = UsgsAstroFrameSensorModel::getReferencePoint();
   csm::ImageCoord referencePointImage = UsgsAstroFrameSensorModel::groundToImage(referencePointGround);
   time_t ephemTime = UsgsAstroFrameSensorModel::getImageTime(referencePointImage);
@@ -695,7 +694,7 @@ std::string UsgsAstroFrameSensorModel::getReferenceDateAndTime() const {
 
 
 std::string UsgsAstroFrameSensorModel::getModelState() const {
-    MESSAGE_LOG(this->m_logger, "Dumping model state");
+    MESSAGE_LOG("Dumping model state");
     json state = {
       {"m_modelName", _SENSOR_MODEL_NAME},
       {"m_sensorName", m_sensorName},
@@ -739,14 +738,14 @@ std::string UsgsAstroFrameSensorModel::getModelState() const {
                                m_referencePointXyz.y,
                                m_referencePointXyz.z}},
       {"m_currentParameterCovariance", m_currentParameterCovariance},
-      {"m_logFile", m_logFile}
+      {"m_logName", m_logName}
     };
 
     return state.dump();
 }
 
 bool UsgsAstroFrameSensorModel::isValidModelState(const std::string& stringState, csm::WarningList *warnings) {
-  MESSAGE_LOG(this->m_logger, "Checking if model has valid state");
+  MESSAGE_LOG("Checking if model has valid state");
   std::vector<std::string> requiredKeywords = {
     "m_modelName",
     "m_majorAxis",
@@ -809,7 +808,7 @@ bool UsgsAstroFrameSensorModel::isValidIsd(const std::string& Isd, csm::WarningL
   // or rather, it would be a pain to maintain, so just check if
   // we can get a valid state from ISD. Once ISD schema is 100% clear
   // we can change this.
-  MESSAGE_LOG(this->m_logger, "Building isd to check model state");
+  MESSAGE_LOG("Building isd to check model state");
    try {
      std::string state = constructStateFromIsd(Isd, warnings);
      return isValidModelState(state, warnings);
@@ -823,7 +822,7 @@ bool UsgsAstroFrameSensorModel::isValidIsd(const std::string& Isd, csm::WarningL
 void UsgsAstroFrameSensorModel::replaceModelState(const std::string& stringState) {
 
     json state = json::parse(stringState);
-    MESSAGE_LOG(this->m_logger, "Replaceing model state");
+    MESSAGE_LOG("Replaceing model state");
     // The json library's .at() will except if key is missing
     try {
         m_modelName = state.at("m_modelName").get<std::string>();
@@ -855,16 +854,7 @@ void UsgsAstroFrameSensorModel::replaceModelState(const std::string& stringState
         // Set reference point to the center of the image
         m_referencePointXyz = imageToGround(csm::ImageCoord(m_nLines/2.0, m_nSamples/2.0));
         m_currentParameterCovariance = state.at("m_currentParameterCovariance").get<std::vector<double>>();
-        m_logFile = state.at("m_logFile").get<std::string>();
-        if (m_logFile.empty()) {
-          m_logger.reset();
-        }
-        else {
-          m_logger = spdlog::get(m_logFile);
-          if (!m_logger) {
-            m_logger = spdlog::basic_logger_mt(m_logFile, m_logFile);
-          }
-        }
+        m_logName = state.at("m_logName").get<std::string>();
     }
     catch(std::out_of_range& e) {
       throw csm::Error(csm::Error::SENSOR_MODEL_NOT_CONSTRUCTIBLE,
@@ -875,9 +865,16 @@ void UsgsAstroFrameSensorModel::replaceModelState(const std::string& stringState
 
 
 std::string UsgsAstroFrameSensorModel::constructStateFromIsd(const std::string& jsonIsd, csm::WarningList* warnings) {
-    MESSAGE_LOG(this->m_logger, "Constructing state from isd");
-    json isd = json::parse(jsonIsd);
+
     json state = {};
+    // Get the optional custom logger
+    state["m_logName"] = "usgscsm_logger";
+    if (m_logName != "usgscsm_logger" && m_logName != "") {
+      state["m_logName"] = m_logName;
+    }
+
+    MESSAGE_LOG("Constructing state from isd");
+    ale::Isd stateIsd(jsonIsd);
 
     csm::WarningList* parsingWarnings = new csm::WarningList;
 
@@ -1006,10 +1003,6 @@ std::string UsgsAstroFrameSensorModel::constructStateFromIsd(const std::string& 
     }
     state["m_collectionIdentifier"] = "";
 
-    // Get the optional logging file
-    state["m_logFile"] = getLogFile(isd);
-
-
     if (!parsingWarnings->empty()) {
       if (warnings) {
         warnings->insert(warnings->end(), parsingWarnings->begin(), parsingWarnings->end());
@@ -1030,33 +1023,33 @@ std::string UsgsAstroFrameSensorModel::constructStateFromIsd(const std::string& 
 
 
 csm::EcefCoord UsgsAstroFrameSensorModel::getReferencePoint() const {
-  MESSAGE_LOG(this->m_logger, "Accessing reference point x: {}, y: {}, z: {}",
+  MESSAGE_LOG("Accessing reference point x: {}, y: {}, z: {}",
                               m_referencePointXyz.x, m_referencePointXyz.y, m_referencePointXyz.z);
   return m_referencePointXyz;
 }
 
 
 void UsgsAstroFrameSensorModel::setReferencePoint(const csm::EcefCoord &groundPt) {
-  MESSAGE_LOG(this->m_logger, "Setting reference point to {}, {}, {}",
+  MESSAGE_LOG("Setting reference point to {}, {}, {}",
                                groundPt.x, groundPt.y, groundPt.z);
   m_referencePointXyz = groundPt;
 }
 
 
 int UsgsAstroFrameSensorModel::getNumParameters() const {
-  MESSAGE_LOG(this->m_logger, "Accessing num parameters: {}", NUM_PARAMETERS);
+  MESSAGE_LOG("Accessing num parameters: {}", NUM_PARAMETERS);
   return NUM_PARAMETERS;
 }
 
 
 std::string UsgsAstroFrameSensorModel::getParameterName(int index) const {
-  MESSAGE_LOG(this->m_logger, "Setting parameter name to {}", index);
+  MESSAGE_LOG("Setting parameter name to {}", index);
   return m_parameterName[index];
 }
 
 
 std::string UsgsAstroFrameSensorModel::getParameterUnits(int index) const {
-  MESSAGE_LOG(this->m_logger, "Accessing parameter units for {}", index);
+  MESSAGE_LOG("Accessing parameter units for {}", index);
   if (index < 3) {
     return "m";
   }
@@ -1067,19 +1060,19 @@ std::string UsgsAstroFrameSensorModel::getParameterUnits(int index) const {
 
 
 bool UsgsAstroFrameSensorModel::hasShareableParameters() const {
-  MESSAGE_LOG(this->m_logger, "Checking for shareable parameters");
+  MESSAGE_LOG("Checking for shareable parameters");
   return false;
 }
 
 
 bool UsgsAstroFrameSensorModel::isParameterShareable(int index) const {
-  MESSAGE_LOG(this->m_logger, "Checking is parameter: {} is shareable", index);
+  MESSAGE_LOG("Checking is parameter: {} is shareable", index);
   return false;
 }
 
 
 csm::SharingCriteria UsgsAstroFrameSensorModel::getParameterSharingCriteria(int index) const {
-   MESSAGE_LOG(this->m_logger, "Checking sharing criteria for parameter {}. "
+   MESSAGE_LOG("Checking sharing criteria for parameter {}. "
                "Sharing is not supported, throwing exception", index);
    // Parameter sharing is not supported for this sensor,
    // all indices are out of range
@@ -1091,39 +1084,39 @@ csm::SharingCriteria UsgsAstroFrameSensorModel::getParameterSharingCriteria(int 
 
 
 double UsgsAstroFrameSensorModel::getParameterValue(int index) const {
-  MESSAGE_LOG(this->m_logger, "Accessing parameter value {} at index: {}", m_currentParameterValue[index], index);
+  MESSAGE_LOG("Accessing parameter value {} at index: {}", m_currentParameterValue[index], index);
   return m_currentParameterValue[index];
 
 }
 
 
 void UsgsAstroFrameSensorModel::setParameterValue(int index, double value) {
-  MESSAGE_LOG(this->m_logger, "Setting parameter value: {} at index: {}", value, index);
+  MESSAGE_LOG("Setting parameter value: {} at index: {}", value, index);
   m_currentParameterValue[index] = value;
 }
 
 
 csm::param::Type UsgsAstroFrameSensorModel::getParameterType(int index) const {
-  MESSAGE_LOG(this->m_logger, "Accessing parameter type: {} at index: {}", m_parameterType[index], index);
+  MESSAGE_LOG("Accessing parameter type: {} at index: {}", m_parameterType[index], index);
   return m_parameterType[index];
 }
 
 
 void UsgsAstroFrameSensorModel::setParameterType(int index, csm::param::Type pType) {
-    MESSAGE_LOG(this->m_logger, "Setting parameter type: {} at index: {}", pType, index);
+    MESSAGE_LOG("Setting parameter type: {} at index: {}", pType, index);
     m_parameterType[index] = pType;
 }
 
 
 double UsgsAstroFrameSensorModel::getParameterCovariance(int index1, int index2) const {
    int index = UsgsAstroFrameSensorModel::NUM_PARAMETERS * index1 + index2;
-   MESSAGE_LOG(this->m_logger, "Accessing parameter covar: {} between index1: {} and index2: {}", m_currentParameterCovariance[index], index1, index2);
+   MESSAGE_LOG("Accessing parameter covar: {} between index1: {} and index2: {}", m_currentParameterCovariance[index], index1, index2);
    return m_currentParameterCovariance[index];
 }
 
 
 void UsgsAstroFrameSensorModel::setParameterCovariance(int index1, int index2, double covariance) {
-   MESSAGE_LOG(this->m_logger, "Setting parameter covar: {} between index1: {} and index2: {}",
+   MESSAGE_LOG("Setting parameter covar: {} between index1: {} and index2: {}",
                                 covariance, index1, index2);
    int index = UsgsAstroFrameSensorModel::NUM_PARAMETERS * index1 + index2;
    m_currentParameterCovariance[index] = covariance;
@@ -1131,13 +1124,13 @@ void UsgsAstroFrameSensorModel::setParameterCovariance(int index1, int index2, d
 
 
 int UsgsAstroFrameSensorModel::getNumGeometricCorrectionSwitches() const {
-  MESSAGE_LOG(this->m_logger, "Accessing num geom correction switches");
+  MESSAGE_LOG("Accessing num geom correction switches");
   return 0;
 }
 
 
 std::string UsgsAstroFrameSensorModel::getGeometricCorrectionName(int index) const {
-   MESSAGE_LOG(this->m_logger, "Accessing name of geometric correction switch {}. "
+   MESSAGE_LOG("Accessing name of geometric correction switch {}. "
                "Geometric correction switches are not supported, throwing exception",
                index);
    // Since there are no geometric corrections, all indices are out of range
@@ -1151,7 +1144,7 @@ std::string UsgsAstroFrameSensorModel::getGeometricCorrectionName(int index) con
 void UsgsAstroFrameSensorModel::setGeometricCorrectionSwitch(int index,
                                                       bool value,
                                                       csm::param::Type pType) {
-   MESSAGE_LOG(this->m_logger, "Setting geometric correction switch {} to {} "
+   MESSAGE_LOG("Setting geometric correction switch {} to {} "
                "with parameter type {}. "
                "Geometric correction switches are not supported, throwing exception",
                index, value, pType);
@@ -1164,7 +1157,7 @@ void UsgsAstroFrameSensorModel::setGeometricCorrectionSwitch(int index,
 
 
 bool UsgsAstroFrameSensorModel::getGeometricCorrectionSwitch(int index) const {
-   MESSAGE_LOG(this->m_logger, "Accessing value of geometric correction switch {}. "
+   MESSAGE_LOG("Accessing value of geometric correction switch {}. "
                "Geometric correction switches are not supported, throwing exception",
                index);
    // Since there are no geometric corrections, all indices are out of range
@@ -1179,7 +1172,7 @@ std::vector<double> UsgsAstroFrameSensorModel::getCrossCovarianceMatrix(
     const GeometricModel &comparisonModel,
     csm::param::Set pSet,
     const GeometricModelList &otherModels) const {
-   MESSAGE_LOG(this->m_logger, "Accessing cross covariance matrix");
+   MESSAGE_LOG("Accessing cross covariance matrix");
 
    // No correlation between models.
    const std::vector<int>& indices = getParameterSetIndices(pSet);
@@ -1192,14 +1185,14 @@ std::vector<double> UsgsAstroFrameSensorModel::getCrossCovarianceMatrix(
 
 
 csm::Ellipsoid UsgsAstroFrameSensorModel::getEllipsoid() const {
-   MESSAGE_LOG(this->m_logger, "Accessing ellipsoid radii {} {}",
+   MESSAGE_LOG("Accessing ellipsoid radii {} {}",
                m_majorAxis, m_minorAxis);
    return csm::Ellipsoid(m_majorAxis, m_minorAxis);
 }
 
 
 void UsgsAstroFrameSensorModel::setEllipsoid(const csm::Ellipsoid &ellipsoid) {
-   MESSAGE_LOG(this->m_logger, "Setting ellipsoid radii {} {}",
+   MESSAGE_LOG("Setting ellipsoid radii {} {}",
                ellipsoid.getSemiMajorRadius(), ellipsoid.getSemiMinorRadius());
    m_majorAxis = ellipsoid.getSemiMajorRadius();
    m_minorAxis = ellipsoid.getSemiMinorRadius();
@@ -1208,7 +1201,7 @@ void UsgsAstroFrameSensorModel::setEllipsoid(const csm::Ellipsoid &ellipsoid) {
 
 void UsgsAstroFrameSensorModel::calcRotationMatrix(
     double m[3][3]) const {
-  MESSAGE_LOG(this->m_logger, "Calculating rotation matrix");
+  MESSAGE_LOG("Calculating rotation matrix");
   // Trigonometric functions for rotation matrix
   double x = m_currentParameterValue[3];
   double y = m_currentParameterValue[4];
@@ -1235,7 +1228,7 @@ void UsgsAstroFrameSensorModel::calcRotationMatrix(
 
 void UsgsAstroFrameSensorModel::calcRotationMatrix(
   double m[3][3], const std::vector<double> &adjustments) const {
-  MESSAGE_LOG(this->m_logger, "Calculating rotation matrix with adjustments");
+  MESSAGE_LOG("Calculating rotation matrix with adjustments");
   // Trigonometric functions for rotation matrix
   double x = getValue(3, adjustments);
   double y = getValue(4, adjustments);
@@ -1266,7 +1259,7 @@ void UsgsAstroFrameSensorModel::losEllipsoidIntersect(
       double&       y,
       double&       z ) const
 {
-   MESSAGE_LOG(this->m_logger, "Calculating losEllipsoidIntersect with height: {},\n\
+   MESSAGE_LOG("Calculating losEllipsoidIntersect with height: {},\n\
                                 xc: {}, yc: {}, zc: {}\n\
                                 xl: {}, yl: {}, zl: {}", height,
                                 xc, yc, zc,
@@ -1306,7 +1299,7 @@ void UsgsAstroFrameSensorModel::losEllipsoidIntersect(
    y = yc + scale * yl;
    z = zc + scale * zl;
 
-   MESSAGE_LOG(this->m_logger, "Calculated losEllipsoidIntersect at: {}, {}, {}",
+   MESSAGE_LOG("Calculated losEllipsoidIntersect at: {}, {}, {}",
                                 x, y, z);
 }
 
@@ -1317,14 +1310,14 @@ double UsgsAstroFrameSensorModel::getValue(
    int index,
    const std::vector<double> &adjustments) const
 {
-   MESSAGE_LOG(this->m_logger, "Accessing value: {} at index: {}, with adjustments", m_currentParameterValue[index] + adjustments[index], index);
+   MESSAGE_LOG("Accessing value: {} at index: {}, with adjustments", m_currentParameterValue[index] + adjustments[index], index);
    return m_currentParameterValue[index] + adjustments[index];
 }
 
-std::shared_ptr<spdlog::logger> UsgsAstroFrameSensorModel::getLogger() {
-  return m_logger;
+std::string UsgsAstroFrameSensorModel::getLogger() {
+  return m_logName;
 }
 
-void UsgsAstroFrameSensorModel::setLogger(std::shared_ptr<spdlog::logger> logger) {
-  m_logger = logger;
+void UsgsAstroFrameSensorModel::setLogger(std::string logName) {
+  m_logName = logName;
 }

--- a/src/UsgsAstroLsSensorModel.cpp
+++ b/src/UsgsAstroLsSensorModel.cpp
@@ -30,7 +30,7 @@
 #include <Error.h>
 #include <json/json.hpp>
 
-#define MESSAGE_LOG(logger, ...) if (logger) { logger->info(__VA_ARGS__); }
+#define MESSAGE_LOG(...) if (spdlog::get(m_logName)) { spdlog::get(m_logName)->info(__VA_ARGS__); }
 
 using json = nlohmann::json;
 using namespace std;
@@ -134,7 +134,7 @@ const csm::param::Type
 //***************************************************************************
 void UsgsAstroLsSensorModel::replaceModelState(const std::string &stateString )
 {
-   MESSAGE_LOG(m_logger, "Replacing model state")
+   MESSAGE_LOG("Replacing model state")
 
    reset();
    auto j = json::parse(stateString);
@@ -146,7 +146,7 @@ void UsgsAstroLsSensorModel::replaceModelState(const std::string &stateString )
    m_nLines = j["m_nLines"];
    m_nSamples = j["m_nSamples"];
    m_platformFlag = j["m_platformFlag"];
-   MESSAGE_LOG(m_logger, "m_imageIdentifier: {} "
+   MESSAGE_LOG("m_imageIdentifier: {} "
                          "m_sensorName: {} "
                          "m_nLines: {} "
                          "m_nSamples: {} "
@@ -168,7 +168,7 @@ void UsgsAstroLsSensorModel::replaceModelState(const std::string &stateString )
    m_startingDetectorSample = j["m_startingDetectorSample"];
    m_startingDetectorLine = j["m_startingDetectorLine"];
    m_ikCode = j["m_ikCode"];
-   MESSAGE_LOG(m_logger, "m_startingEphemerisTime: {} "
+   MESSAGE_LOG("m_startingEphemerisTime: {} "
                          "m_centerEphemerisTime: {} "
                          "m_detectorSampleSumming: {} "
                          "m_detectorLineSumming: {} "
@@ -184,7 +184,7 @@ void UsgsAstroLsSensorModel::replaceModelState(const std::string &stateString )
    m_zDirection = j["m_zDirection"];
    m_distortionType = (DistortionType)j["m_distortionType"].get<int>();
    m_opticalDistCoeffs = j["m_opticalDistCoeffs"].get<std::vector<double>>();
-   MESSAGE_LOG(m_logger, "m_focalLength: {} "
+   MESSAGE_LOG("m_focalLength: {} "
                          "m_zDirection: {} "
                          "m_distortionType: {} ",
                          j["m_focalLength"].dump(), j["m_zDirection"].dump(),
@@ -199,7 +199,7 @@ void UsgsAstroLsSensorModel::replaceModelState(const std::string &stateString )
    m_detectorLineOrigin = j["m_detectorLineOrigin"];
    m_majorAxis = j["m_majorAxis"];
    m_minorAxis = j["m_minorAxis"];
-   MESSAGE_LOG(m_logger, "m_detectorSampleOrigin: {} "
+   MESSAGE_LOG("m_detectorSampleOrigin: {} "
                          "m_detectorLineOrigin: {} "
                          "m_majorAxis: {} "
                          "m_minorAxis: {} ",
@@ -209,14 +209,14 @@ void UsgsAstroLsSensorModel::replaceModelState(const std::string &stateString )
 
    m_platformIdentifier = j["m_platformIdentifier"];
    m_sensorIdentifier = j["m_sensorIdentifier"];
-   MESSAGE_LOG(m_logger, "m_platformIdentifier: {} "
+   MESSAGE_LOG("m_platformIdentifier: {} "
                          "m_sensorIdentifier: {} ",
                          j["m_platformIdentifier"].dump(),
                          j["m_sensorIdentifier"].dump())
 
    m_minElevation = j["m_minElevation"];
    m_maxElevation = j["m_maxElevation"];
-   MESSAGE_LOG(m_logger, "m_minElevation: {} "
+   MESSAGE_LOG("m_minElevation: {} "
                          "m_maxElevation: {} ",
                          j["m_minElevation"].dump(),
                          j["m_maxElevation"].dump())
@@ -226,7 +226,7 @@ void UsgsAstroLsSensorModel::replaceModelState(const std::string &stateString )
    m_dtQuat = j["m_dtQuat"];
    m_t0Quat = j["m_t0Quat"];
    m_numPositions = j["m_numPositions"];
-   MESSAGE_LOG(m_logger, "m_dtEphem: {} "
+   MESSAGE_LOG("m_dtEphem: {} "
                          "m_t0Ephem: {} "
                          "m_dtQuat: {} "
                          "m_t0Quat: {} ",
@@ -237,7 +237,7 @@ void UsgsAstroLsSensorModel::replaceModelState(const std::string &stateString )
    m_referencePointXyz.x = j["m_referencePointXyz"][0];
    m_referencePointXyz.y = j["m_referencePointXyz"][1];
    m_referencePointXyz.z = j["m_referencePointXyz"][2];
-   MESSAGE_LOG(m_logger, "m_numQuaternions: {} "
+   MESSAGE_LOG("m_numQuaternions: {} "
                          "m_referencePointX: {} "
                          "m_referencePointY: {} "
                          "m_referencePointZ: {} ",
@@ -249,7 +249,7 @@ void UsgsAstroLsSensorModel::replaceModelState(const std::string &stateString )
    m_flyingHeight = j["m_flyingHeight"];
    m_halfSwath = j["m_halfSwath"];
    m_halfTime = j["m_halfTime"];
-   MESSAGE_LOG(m_logger, "m_gsd: {} "
+   MESSAGE_LOG("m_gsd: {} "
                          "m_flyingHeight: {} "
                          "m_halfSwath: {} "
                          "m_halfTime: {} ",
@@ -265,16 +265,7 @@ void UsgsAstroLsSensorModel::replaceModelState(const std::string &stateString )
    m_sunPosition = j["m_sunPosition"].get<std::vector<double>>();
    m_sunVelocity = j["m_sunVelocity"].get<std::vector<double>>();
 
-   m_logFile = j["m_logFile"].get<std::string>();
-   if (m_logFile.empty()) {
-     m_logger.reset();
-   }
-   else {
-     m_logger = spdlog::get(m_logFile);
-     if (!m_logger) {
-       m_logger = spdlog::basic_logger_mt(m_logFile, m_logFile);
-     }
-   }
+   m_logName = j["m_logName"].get<std::string>();
 
    for (int i = 0; i < num_params; i++) {
      for (int k = 0; k < NUM_PARAM_TYPES; k++) {
@@ -335,7 +326,7 @@ std::string UsgsAstroLsSensorModel::getModelNameFromModelState(
 // UsgsAstroLineScannerSensorModel::getModelState
 //***************************************************************************
 std::string UsgsAstroLsSensorModel::getModelState() const {
-      MESSAGE_LOG(m_logger, "Running getModelState")
+      MESSAGE_LOG("Running getModelState")
 
       json state;
       state["m_modelName"] = _SENSOR_MODEL_NAME;
@@ -346,7 +337,7 @@ std::string UsgsAstroLsSensorModel::getModelState() const {
       state["m_nLines"] = m_nLines;
       state["m_nSamples"] = m_nSamples;
       state["m_platformFlag"] = m_platformFlag;
-      MESSAGE_LOG(m_logger, "m_imageIdentifier: {} "
+      MESSAGE_LOG("m_imageIdentifier: {} "
                                   "m_sensorName: {} "
                                   "m_nLines: {} "
                                   "m_nSamples: {} "
@@ -359,7 +350,7 @@ std::string UsgsAstroLsSensorModel::getModelState() const {
       state["m_intTimes"] = m_intTimes;
       state["m_startingEphemerisTime"] = m_startingEphemerisTime;
       state["m_centerEphemerisTime"] = m_centerEphemerisTime;
-      MESSAGE_LOG(m_logger, "m_startingEphemerisTime: {} "
+      MESSAGE_LOG("m_startingEphemerisTime: {} "
                                   "m_centerEphemerisTime: {} ",
                                   m_startingEphemerisTime,
                                   m_centerEphemerisTime)
@@ -368,7 +359,7 @@ std::string UsgsAstroLsSensorModel::getModelState() const {
       state["m_detectorLineSumming"] = m_detectorLineSumming;
       state["m_startingDetectorSample"] = m_startingDetectorSample;
       state["m_ikCode"] = m_ikCode;
-      MESSAGE_LOG(m_logger, "m_detectorSampleSumming: {} "
+      MESSAGE_LOG("m_detectorSampleSumming: {} "
                             "m_detectorLineSumming: {} "
                             "m_startingDetectorSample: {} "
                             "m_ikCode: {} ",
@@ -380,7 +371,7 @@ std::string UsgsAstroLsSensorModel::getModelState() const {
       state["m_zDirection"] = m_zDirection;
       state["m_distortionType"] = m_distortionType;
       state["m_opticalDistCoeffs"] = m_opticalDistCoeffs;
-      MESSAGE_LOG(m_logger, "m_focalLength: {} "
+      MESSAGE_LOG("m_focalLength: {} "
                                   "m_zDirection: {} "
                                   "m_distortionType (0-Radial, 1-Transverse): {} ",
                                   m_focalLength, m_zDirection,
@@ -393,7 +384,7 @@ std::string UsgsAstroLsSensorModel::getModelState() const {
       state["m_detectorLineOrigin"] = m_detectorLineOrigin;
       state["m_majorAxis"] = m_majorAxis;
       state["m_minorAxis"] = m_minorAxis;
-      MESSAGE_LOG(m_logger, "m_detectorSampleOrigin: {} "
+      MESSAGE_LOG("m_detectorSampleOrigin: {} "
                                   "m_detectorLineOrigin: {} "
                                   "m_majorAxis: {} "
                                   "m_minorAxis: {} ",
@@ -404,7 +395,7 @@ std::string UsgsAstroLsSensorModel::getModelState() const {
       state["m_sensorIdentifier"] = m_sensorIdentifier;
       state["m_minElevation"] = m_minElevation;
       state["m_maxElevation"] = m_maxElevation;
-      MESSAGE_LOG(m_logger, "m_platformIdentifier: {} "
+      MESSAGE_LOG("m_platformIdentifier: {} "
                                   "m_sensorIdentifier: {} "
                                   "m_minElevation: {} "
                                   "m_maxElevation: {} ",
@@ -415,7 +406,7 @@ std::string UsgsAstroLsSensorModel::getModelState() const {
       state["m_t0Ephem"] = m_t0Ephem;
       state["m_dtQuat"] = m_dtQuat;
       state["m_t0Quat"] = m_t0Quat;
-      MESSAGE_LOG(m_logger, "m_dtEphem: {} "
+      MESSAGE_LOG("m_dtEphem: {} "
                                   "m_t0Ephem: {} "
                                   "m_dtQuat: {} "
                                   "m_t0Quat: {} ",
@@ -427,7 +418,7 @@ std::string UsgsAstroLsSensorModel::getModelState() const {
       state["m_positions"] = m_positions;
       state["m_velocities"] = m_velocities;
       state["m_quaternions"] = m_quaternions;
-      MESSAGE_LOG(m_logger, "m_numPositions: {} "
+      MESSAGE_LOG("m_numPositions: {} "
                             "m_numQuaternions: {} ",
                              m_numPositions, m_numQuaternions)
 
@@ -439,7 +430,7 @@ std::string UsgsAstroLsSensorModel::getModelState() const {
       state["m_halfSwath"] = m_halfSwath;
       state["m_halfTime"] = m_halfTime;
       state["m_covariance"] = m_covariance;
-      MESSAGE_LOG(m_logger, "m_gsd: {} "
+      MESSAGE_LOG("m_gsd: {} "
                             "m_flyingHeight: {} "
                             "m_halfSwath: {} "
                             "m_halfTime: {} ",
@@ -450,19 +441,19 @@ std::string UsgsAstroLsSensorModel::getModelState() const {
       state["m_referencePointXyz"][0] = m_referencePointXyz.x;
       state["m_referencePointXyz"][1] = m_referencePointXyz.y;
       state["m_referencePointXyz"][2] = m_referencePointXyz.z;
-      MESSAGE_LOG(m_logger, "m_referencePointXyz: {} "
+      MESSAGE_LOG("m_referencePointXyz: {} "
                             "m_referencePointXyz: {} "
                             "m_referencePointXyz: {} ",
                              m_referencePointXyz.x, m_referencePointXyz.y,
                              m_referencePointXyz.z)
 
       state["m_sunPosition"] = m_sunPosition;
-      MESSAGE_LOG(m_logger, "num sun positions: {} ", m_sunPosition.size())
+      MESSAGE_LOG("num sun positions: {} ", m_sunPosition.size())
 
       state["m_sunVelocity"] = m_sunVelocity;
-      MESSAGE_LOG(m_logger, "num sun velocities: {} ", m_sunVelocity.size())
+      MESSAGE_LOG("num sun velocities: {} ", m_sunVelocity.size())
 
-      state["m_logFile"] = m_logFile;
+      state["m_logName"] = m_logName;
 
       return state.dump();
  }
@@ -472,7 +463,7 @@ std::string UsgsAstroLsSensorModel::getModelState() const {
  //***************************************************************************
 void UsgsAstroLsSensorModel::reset()
 {
-  MESSAGE_LOG(m_logger, "Running reset()")
+  MESSAGE_LOG("Running reset()")
   _linear = false; // default until a linear model is made
   _u0    = 0.0;
   _du_dx = 0.0;
@@ -544,8 +535,7 @@ void UsgsAstroLsSensorModel::reset()
 
   m_covariance = std::vector<double>(NUM_PARAMETERS * NUM_PARAMETERS,0.0); // 52
 
-  m_logFile = "";
-  m_logger.reset();
+  m_logName = "usgscsm_logger";
 }
 
 //*****************************************************************************
@@ -571,17 +561,17 @@ void UsgsAstroLsSensorModel::updateState()
 {
    // If sensor model is being created for the first time
    // This routine will set some parameters not found in the ISD.
-   MESSAGE_LOG(m_logger, "Updating State")
+   MESSAGE_LOG("Updating State")
    // Reference point (image center)
    double lineCtr = m_nLines / 2.0;
    double sampCtr = m_nSamples / 2.0;
    csm::ImageCoord ip(lineCtr, sampCtr);
-   MESSAGE_LOG(m_logger, "updateState: center image coordinate set to {} {}",
+   MESSAGE_LOG("updateState: center image coordinate set to {} {}",
                                lineCtr, sampCtr)
 
    double refHeight = 0;
    m_referencePointXyz = imageToGround(ip, refHeight);
-   MESSAGE_LOG(m_logger, "updateState: reference point (x, y, z) {} {} {}",
+   MESSAGE_LOG("updateState: reference point (x, y, z) {} {} {}",
                                 m_referencePointXyz.x, m_referencePointXyz.y,
                                 m_referencePointXyz.z)
 
@@ -593,7 +583,7 @@ void UsgsAstroLsSensorModel::updateState()
    double dy = delta.y - m_referencePointXyz.y;
    double dz = delta.z - m_referencePointXyz.z;
    m_gsd = sqrt((dx*dx + dy*dy + dz*dz) / 2.0);
-   MESSAGE_LOG(m_logger, "updateState: ground sample distance set to {} "
+   MESSAGE_LOG("updateState: ground sample distance set to {} "
                               "based on dx {} dy {} dz {}",
                                m_gsd, dx, dy, dz)
 
@@ -603,20 +593,20 @@ void UsgsAstroLsSensorModel::updateState()
    dy = sensorPos.y - m_referencePointXyz.y;
    dz = sensorPos.z - m_referencePointXyz.z;
    m_flyingHeight = sqrt(dx*dx + dy*dy + dz*dz);
-   MESSAGE_LOG(m_logger, "updateState: flight height set to {}"
+   MESSAGE_LOG("updateState: flight height set to {}"
                               "based on dx {} dy {} dz {}",
                                m_flyingHeight, dx, dy, dz)
 
    // Compute half swath
    m_halfSwath = m_gsd * m_nSamples / 2.0;
-   MESSAGE_LOG(m_logger, "updateState: half swath set to {}",
+   MESSAGE_LOG("updateState: half swath set to {}",
                                m_halfSwath)
 
    // Compute half time duration
    double fullImageTime = m_intTimeStartTimes.back() - m_intTimeStartTimes.front()
                           + m_intTimes.back() * (m_nLines - m_intTimeLines.back());
    m_halfTime = fullImageTime / 2.0;
-   MESSAGE_LOG(m_logger, "updateState: half time duration set to {}",
+   MESSAGE_LOG("updateState: half time duration set to {}",
                                m_halfTime)
 
    // Parameter covariance, hardcoded accuracy values
@@ -667,7 +657,7 @@ csm::ImageCoord UsgsAstroLsSensorModel::groundToImage(
    csm::WarningList*     warnings) const
 {
 
-  MESSAGE_LOG(m_logger, "Computing groundToImage(No adjustments) for {}, {}, {}, with desired precision {}",
+  MESSAGE_LOG("Computing groundToImage(No adjustments) for {}, {}, {}, with desired precision {}",
               ground_pt.x, ground_pt.y, ground_pt.z, desired_precision);
 
    // The public interface invokes the private interface with no adjustments.
@@ -742,7 +732,7 @@ csm::ImageCoord UsgsAstroLsSensorModel::groundToImage(
      *achievedPrecision = finalUpdate;
    }
 
-   MESSAGE_LOG(m_logger, "groundToImage: image line sample {} {}",
+   MESSAGE_LOG("groundToImage: image line sample {} {}",
                                 approxPt.line, approxPt.samp)
 
    if (warnings && (desiredPrecision > 0.0) && (abs(finalUpdate) > desiredPrecision))
@@ -766,7 +756,7 @@ csm::ImageCoordCovar UsgsAstroLsSensorModel::groundToImage(
    double* achieved_precision,
    csm::WarningList* warnings) const
 {
-  MESSAGE_LOG(m_logger, "Computing groundToImage(Covar) for {}, {}, {}, with desired precision {}",
+  MESSAGE_LOG("Computing groundToImage(Covar) for {}, {}, {}, with desired precision {}",
                 groundPt.x, groundPt.y, groundPt.z, desired_precision);
    // Ground to image with error propagation
    // Compute corresponding image point
@@ -839,7 +829,7 @@ csm::EcefCoord UsgsAstroLsSensorModel::imageToGround(
    double* achieved_precision,
    csm::WarningList* warnings) const
 {
-   MESSAGE_LOG(m_logger, "Computing imageToGround for {}, {}, {}, with desired precision {}",
+   MESSAGE_LOG("Computing imageToGround for {}, {}, {}, with desired precision {}",
                image_pt.line, image_pt.samp, height, desired_precision);
    double xc, yc, zc;
    double vx, vy, vz;
@@ -867,7 +857,7 @@ csm::EcefCoord UsgsAstroLsSensorModel::imageToGround(
    }
 
 /*
-    MESSAGE_LOG(m_logger, "imageToGround for {} {} {} achieved precision {}",
+    MESSAGE_LOG("imageToGround for {} {} {} achieved precision {}",
                                 image_pt.line, image_pt.samp, height, achieved_precision)
 */
 
@@ -881,7 +871,7 @@ void UsgsAstroLsSensorModel::determineSensorCovarianceInImageSpace(
    csm::EcefCoord &gp,
    double         sensor_cov[4] ) const
 {
-   MESSAGE_LOG(m_logger, "Calculating determineSensorCovarianceInImageSpace for {} {} {}",
+   MESSAGE_LOG("Calculating determineSensorCovarianceInImageSpace for {} {} {}",
                               gp.x, gp.y, gp.z)
 
 
@@ -919,7 +909,7 @@ csm::EcefCoordCovar UsgsAstroLsSensorModel::imageToGround(
    double* achieved_precision,
    csm::WarningList* warnings) const
 {
-  MESSAGE_LOG(m_logger, "Calculating imageToGround (with error propagation) for {}, {}, {} with height varinace {} and desired precision {}",
+  MESSAGE_LOG("Calculating imageToGround (with error propagation) for {}, {}, {} with height varinace {} and desired precision {}",
                               image_pt.line, image_pt.samp, height, heightVariance, desired_precision)
    // Image to ground with error propagation
    // Use numerical partials
@@ -1007,7 +997,7 @@ csm::EcefLocus UsgsAstroLsSensorModel::imageToProximateImagingLocus(
    csm::WarningList* warnings) const
 {
 
-  MESSAGE_LOG(m_logger, "Computing imageToProximateImagingLocus (ground {}, {}, {}) for image point {}, {} with desired precision {}",
+  MESSAGE_LOG("Computing imageToProximateImagingLocus (ground {}, {}, {}) for image point {}, {} with desired precision {}",
                               ground_pt.x, ground_pt.y, ground_pt.z, image_pt.line, image_pt.samp, desired_precision);
 
    // Object ray unit direction near given ground location
@@ -1074,7 +1064,7 @@ csm::EcefLocus UsgsAstroLsSensorModel::imageToRemoteImagingLocus(
    csm::WarningList* warnings) const
 {
 
-  MESSAGE_LOG(m_logger, "Calculating imageToRemoteImagingLocus for point {}, {} with desired precision {}",
+  MESSAGE_LOG("Calculating imageToRemoteImagingLocus for point {}, {} with desired precision {}",
                               image_pt.line, image_pt.samp, desired_precision)
 
   double vx, vy, vz;
@@ -1102,7 +1092,7 @@ std::vector<double> UsgsAstroLsSensorModel::computeGroundPartials(
    const csm::EcefCoord& ground_pt) const
 {
 
-   MESSAGE_LOG(m_logger, "Computing computeGroundPartials for point {}, {}, {}",
+   MESSAGE_LOG("Computing computeGroundPartials for point {}, {}, {}",
                                 ground_pt.x, ground_pt.y, ground_pt.z)
 
    double GND_DELTA = m_gsd;
@@ -1139,7 +1129,7 @@ csm::RasterGM::SensorPartials UsgsAstroLsSensorModel::computeSensorPartials(
    csm::WarningList* warnings) const
 {
 
-  MESSAGE_LOG(m_logger, "Calculating computeSensorPartials for ground point {}, {}, {} with desired precision {}",
+  MESSAGE_LOG("Calculating computeSensorPartials for ground point {}, {}, {} with desired precision {}",
                               ground_pt.x, ground_pt.y, ground_pt.z, desired_precision)
 
    // Compute image coordinate first
@@ -1163,7 +1153,7 @@ csm::RasterGM::SensorPartials UsgsAstroLsSensorModel::computeSensorPartials(
    csm::WarningList*      warnings) const
 {
 
-  MESSAGE_LOG(m_logger, "Calculating computeSensorPartials (with image points {}, {}) for ground point {}, {}, {} with desired precision {}",
+  MESSAGE_LOG("Calculating computeSensorPartials (with image points {}, {}) for ground point {}, {}, {} with desired precision {}",
                               image_pt.line, image_pt.samp, ground_pt.x, ground_pt.y, ground_pt.z, desired_precision)
 
    // Compute numerical partials ls wrt specific parameter
@@ -1192,7 +1182,7 @@ UsgsAstroLsSensorModel::computeAllSensorPartials(
    double*               achieved_precision,
    csm::WarningList*     warnings) const
 {
-  MESSAGE_LOG(m_logger, "Computing computeAllSensorPartials for ground point {}, {}, {} with desired precision {}",
+  MESSAGE_LOG("Computing computeAllSensorPartials for ground point {}, {}, {} with desired precision {}",
                               ground_pt.x, ground_pt.y, ground_pt.z, desired_precision)
    csm::ImageCoord image_pt = groundToImage(
       ground_pt, desired_precision, achieved_precision, warnings);
@@ -1214,7 +1204,7 @@ UsgsAstroLsSensorModel::computeAllSensorPartials(
    csm::WarningList*      warnings) const
 {
 
-   MESSAGE_LOG(m_logger, "Computing computeAllSensorPartials for image {} {} and ground {}, {}, {} with desired precision {}",
+   MESSAGE_LOG("Computing computeAllSensorPartials for image {} {} and ground {}, {}, {} with desired precision {}",
                                 image_pt.line, image_pt.samp, ground_pt.x, ground_pt.y, ground_pt.z, desired_precision)
 
    std::vector<int> indices = getParameterSetIndices(pSet);
@@ -1240,7 +1230,7 @@ double UsgsAstroLsSensorModel::getParameterCovariance(
 
    int index = UsgsAstroLsSensorModel::NUM_PARAMETERS * index1 + index2;
 
-   MESSAGE_LOG(m_logger, "getParameterCovariance for {} {} is {}",
+   MESSAGE_LOG("getParameterCovariance for {} {} is {}",
                                 index1, index2, m_covariance[index])
 
    return m_covariance[index];
@@ -1256,7 +1246,7 @@ void UsgsAstroLsSensorModel::setParameterCovariance(
 {
    int index = UsgsAstroLsSensorModel::NUM_PARAMETERS * index1 + index2;
 
-   MESSAGE_LOG(m_logger, "setParameterCovariance for {} {} is {}",
+   MESSAGE_LOG("setParameterCovariance for {} {} is {}",
                                 index1, index2, m_covariance[index])
 
    m_covariance[index] = covariance;
@@ -1315,7 +1305,7 @@ double UsgsAstroLsSensorModel::getImageTime(
    double time = m_intTimeStartTimes[referenceIndex]
       + m_intTimes[referenceIndex] * (lineFull - m_intTimeLines[referenceIndex] + 0.5);
 
-   MESSAGE_LOG(m_logger, "getImageTime for image line {} is {}",
+   MESSAGE_LOG("getImageTime for image line {} is {}",
                          image_pt.line, time)
 
    return time;
@@ -1327,7 +1317,7 @@ double UsgsAstroLsSensorModel::getImageTime(
 csm::EcefCoord UsgsAstroLsSensorModel::getSensorPosition(
    const csm::ImageCoord& imagePt) const
 {
-   MESSAGE_LOG(m_logger, "getSensorPosition at line {}",
+   MESSAGE_LOG("getSensorPosition at line {}",
                                 imagePt.line)
 
    return getSensorPosition(getImageTime(imagePt));
@@ -1342,7 +1332,7 @@ csm::EcefCoord UsgsAstroLsSensorModel::getSensorPosition(double time) const
    double x, y, z, vx, vy, vz;
    getAdjSensorPosVel(time, _no_adjustment, x, y, z, vx, vy, vz);
 
-   MESSAGE_LOG(m_logger, "getSensorPosition at {}",
+   MESSAGE_LOG("getSensorPosition at {}",
                                 time)
 
    return csm::EcefCoord(x, y, z);
@@ -1354,7 +1344,7 @@ csm::EcefCoord UsgsAstroLsSensorModel::getSensorPosition(double time) const
 csm::EcefVector UsgsAstroLsSensorModel::getSensorVelocity(
    const csm::ImageCoord& imagePt) const
 {
-  MESSAGE_LOG(m_logger, "getSensorVelocity at {}",
+  MESSAGE_LOG("getSensorVelocity at {}",
                                imagePt.line)
    return getSensorVelocity(getImageTime(imagePt));
 }
@@ -1367,7 +1357,7 @@ csm::EcefVector UsgsAstroLsSensorModel::getSensorVelocity(double time) const
    double x, y, z, vx, vy, vz;
    getAdjSensorPosVel(time, _no_adjustment, x, y, z, vx, vy, vz);
 
-   MESSAGE_LOG(m_logger, "getSensorVelocity at {}",
+   MESSAGE_LOG("getSensorVelocity at {}",
                                 time)
 
    return csm::EcefVector(vx, vy, vz);
@@ -1627,7 +1617,7 @@ UsgsAstroLsSensorModel::getValidImageRange() const
 csm::EcefVector UsgsAstroLsSensorModel::getIlluminationDirection(
    const csm::EcefCoord& groundPt) const
 {
-  MESSAGE_LOG(m_logger, "Accessing illumination direction of ground point"
+  MESSAGE_LOG("Accessing illumination direction of ground point"
               "{} {} {}.",
               groundPt.x, groundPt.y, groundPt.z);
 
@@ -1663,7 +1653,7 @@ int UsgsAstroLsSensorModel::getNumGeometricCorrectionSwitches() const
 //***************************************************************************
 std::string UsgsAstroLsSensorModel::getGeometricCorrectionName(int index) const
 {
-  MESSAGE_LOG(m_logger, "Accessing name of geometric correction switch {}. "
+  MESSAGE_LOG("Accessing name of geometric correction switch {}. "
               "Geometric correction switches are not supported, throwing exception",
               index);
    // Since there are no geometric corrections, all indices are out of range
@@ -1682,7 +1672,7 @@ void UsgsAstroLsSensorModel::setGeometricCorrectionSwitch(
    csm::param::Type pType)
 
 {
-   MESSAGE_LOG(m_logger, "Setting geometric correction switch {} to {} "
+   MESSAGE_LOG("Setting geometric correction switch {} to {} "
                "with parameter type {}. "
                "Geometric correction switches are not supported, throwing exception",
                index, value, pType);
@@ -1698,7 +1688,7 @@ void UsgsAstroLsSensorModel::setGeometricCorrectionSwitch(
 //***************************************************************************
 bool UsgsAstroLsSensorModel::getGeometricCorrectionSwitch(int index) const
 {
-   MESSAGE_LOG(m_logger, "Accessing value of geometric correction switch {}. "
+   MESSAGE_LOG("Accessing value of geometric correction switch {}. "
                "Geometric correction switches are not supported, throwing exception",
                index);
    // Since there are no geometric corrections, all indices are out of range
@@ -1791,7 +1781,7 @@ bool UsgsAstroLsSensorModel::isParameterShareable(int index) const
 csm::SharingCriteria UsgsAstroLsSensorModel::getParameterSharingCriteria(
    int index) const
 {
-  MESSAGE_LOG(m_logger, "Checking sharing criteria for parameter {}. "
+  MESSAGE_LOG("Checking sharing criteria for parameter {}. "
               "Sharing is not supported, throwing exception", index);
    // Parameter sharing is not supported for this sensor,
    // all indices are out of range
@@ -1862,7 +1852,7 @@ void UsgsAstroLsSensorModel::getQuaternions(const double& time, double q[4]) con
   if (m_numQuaternions < 6 && nOrder == 8)
      nOrderQuat = 4;
 
-  MESSAGE_LOG(m_logger, "Calculating getQuaternions for time {} with {}"
+  MESSAGE_LOG("Calculating getQuaternions for time {} with {}"
                               "order lagrange",
                               time, nOrder)
   lagrangeInterp(
@@ -1877,7 +1867,7 @@ void UsgsAstroLsSensorModel::calculateAttitudeCorrection(
    const std::vector<double>& adj,
    double attCorr[9]) const
 {
-  MESSAGE_LOG(m_logger, "Computing calculateAttitudeCorrection (with adjustment)"
+  MESSAGE_LOG("Computing calculateAttitudeCorrection (with adjustment)"
                               "for time {}", time)
   double aTime = time - m_t0Quat;
   double euler[3];
@@ -1889,7 +1879,7 @@ void UsgsAstroLsSensorModel::calculateAttitudeCorrection(
     (getValue(7, adj) + getValue(10, adj)* nTime + getValue(13, adj)* nTime2) / m_flyingHeight;
   euler[2] =
     (getValue(8, adj) + getValue(11, adj)* nTime + getValue(14, adj)* nTime2) / m_halfSwath;
-  MESSAGE_LOG(m_logger, "calculateAttitudeCorrection: euler {} {} {}",
+  MESSAGE_LOG("calculateAttitudeCorrection: euler {} {} {}",
                               euler[0], euler[1], euler[2])
 
   calculateRotationMatrixFromEuler(euler, attCorr);
@@ -1916,7 +1906,7 @@ void UsgsAstroLsSensorModel::losToEcf(
    //# private_func_description
    // Computes image ray (look vector) in ecf coordinate system.
    // Compute adjusted sensor position and velocity
-   MESSAGE_LOG(m_logger, "Computing losToEcf (with adjustments) for"
+   MESSAGE_LOG("Computing losToEcf (with adjustments) for"
                                "line {} sample {}",
                                 line, sample)
 
@@ -1936,7 +1926,7 @@ void UsgsAstroLsSensorModel::losToEcf(
          m_startingDetectorSample, m_startingDetectorLine,
          m_iTransS, m_iTransL,
          distortedFocalPlaneX, distortedFocalPlaneY);
-   MESSAGE_LOG(m_logger, "losToEcf: distorted focal plane coordinate {} {}",
+   MESSAGE_LOG("losToEcf: distorted focal plane coordinate {} {}",
                          distortedFocalPlaneX, distortedFocalPlaneY)
 
    // Remove lens
@@ -1945,7 +1935,7 @@ void UsgsAstroLsSensorModel::losToEcf(
                     undistortedFocalPlaneX, undistortedFocalPlaneY,
                     m_opticalDistCoeffs,
                     m_distortionType);
-   MESSAGE_LOG(m_logger, "losToEcf: undistorted focal plane coordinate {} {}",
+   MESSAGE_LOG("losToEcf: undistorted focal plane coordinate {} {}",
                          undistortedFocalPlaneX, undistortedFocalPlaneY)
 
   // Define imaging ray (look vector) in camera space
@@ -1953,7 +1943,7 @@ void UsgsAstroLsSensorModel::losToEcf(
    createCameraLookVector(undistortedFocalPlaneX, undistortedFocalPlaneY,
                           m_zDirection, m_focalLength * (1 - getValue(15, adj) / m_halfSwath),
                           cameraLook);
-   MESSAGE_LOG(m_logger, "losToEcf: uncorrected camera look vector {} {} {}",
+   MESSAGE_LOG("losToEcf: uncorrected camera look vector {} {} {}",
                          cameraLook[0], cameraLook[1], cameraLook[2])
 
    // Apply attitude correction
@@ -1970,7 +1960,7 @@ void UsgsAstroLsSensorModel::losToEcf(
    correctedCameraLook[2] = attCorr[6] * cameraLook[0]
                           + attCorr[7] * cameraLook[1]
                           + attCorr[8] * cameraLook[2];
-   MESSAGE_LOG(m_logger, "losToEcf: corrected camera look vector {} {} {}",
+   MESSAGE_LOG("losToEcf: corrected camera look vector {} {} {}",
                                correctedCameraLook[0], correctedCameraLook[1],
                                correctedCameraLook[2])
 // Rotate the look vector into the body fixed frame from the camera reference frame by applying the rotation matrix from the sensor quaternions
@@ -1988,7 +1978,7 @@ void UsgsAstroLsSensorModel::losToEcf(
    bodyLookZ = cameraToBody[6] * correctedCameraLook[0]
              + cameraToBody[7] * correctedCameraLook[1]
              + cameraToBody[8] * correctedCameraLook[2];
-   MESSAGE_LOG(m_logger, "losToEcf: body look vector {} {} {}",
+   MESSAGE_LOG("losToEcf: body look vector {} {} {}",
                                 bodyLookX, bodyLookY, bodyLookZ)
 
 }
@@ -2008,7 +1998,7 @@ void UsgsAstroLsSensorModel::lightAberrationCorr(
    double&       dyl,
    double&       dzl) const
 {
-   MESSAGE_LOG(m_logger, "Computing lightAberrationCorr for camera velocity"
+   MESSAGE_LOG("Computing lightAberrationCorr for camera velocity"
                                "{} {} {} and image ray {} {} {}",
                                 vx, vy, vz, xl, yl, zl)
    //# func_description
@@ -2029,7 +2019,7 @@ void UsgsAstroLsSensorModel::lightAberrationCorr(
       dxl = 0.0;
       dyl = 0.0;
       dzl = 0.0;
-      MESSAGE_LOG(m_logger, "lightAberrationCorr: image ray is parallel"
+      MESSAGE_LOG("lightAberrationCorr: image ray is parallel"
                                   "to velocity vector")
    }
 
@@ -2049,7 +2039,7 @@ void UsgsAstroLsSensorModel::lightAberrationCorr(
    dxl = cfac * vx;
    dyl = cfac * vy;
    dzl = cfac * vz;
-   MESSAGE_LOG(m_logger, "lightAberrationCorr: light of sight correction"
+   MESSAGE_LOG("lightAberrationCorr: light of sight correction"
                                "{} {} {}", dxl, dyl, dzl)
 }
 
@@ -2070,7 +2060,7 @@ void UsgsAstroLsSensorModel::losEllipsoidIntersect(
    double&       achieved_precision,
    const double& desired_precision) const
 {
-   MESSAGE_LOG(m_logger, "Computing losEllipsoidIntersect for camera position "
+   MESSAGE_LOG("Computing losEllipsoidIntersect for camera position "
                                "{} {} {} looking {} {} {} with desired precision"
                                "{}",
                                 xc, yc, zc, xl, yl, zl, desired_precision)
@@ -2123,7 +2113,7 @@ void UsgsAstroLsSensorModel::losEllipsoidIntersect(
    slope = -1;
 
    achieved_precision = fabs(height - h);
-   MESSAGE_LOG(m_logger, "losEllipsoidIntersect: found intersect at {} {} {}"
+   MESSAGE_LOG("losEllipsoidIntersect: found intersect at {} {} {}"
                                 "with achieved precision of {}",
                                 x, y, z, achieved_precision)
 }
@@ -2145,7 +2135,7 @@ void UsgsAstroLsSensorModel::losPlaneIntersect(
                           //         0(X), 1(Y), or 2(Z) fixed
                           // output: 0(X), 1(Y), or 2(Z) fixed
 {
-  MESSAGE_LOG(m_logger, "Calculating losPlaneIntersect for camera position"
+  MESSAGE_LOG("Calculating losPlaneIntersect for camera position"
                               "{} {} {} and image ray {} {} {}",
                               xc, yc, zc, xl, yl, zl)
    //# func_description
@@ -2170,7 +2160,7 @@ void UsgsAstroLsSensorModel::losPlaneIntersect(
          mode = 2;
       }
    }
-   MESSAGE_LOG(m_logger, "losPlaneIntersect: largest/fixed image ray component"
+   MESSAGE_LOG("losPlaneIntersect: largest/fixed image ray component"
                                 "{} (1-x, 2-y, 3-z)", mode)
    // X is the fixed or largest component
 
@@ -2195,7 +2185,7 @@ void UsgsAstroLsSensorModel::losPlaneIntersect(
       x = xc + (z - zc) * xl / zl;
       y = yc + (z - zc) * yl / zl;
    }
-   MESSAGE_LOG(m_logger, "ground coordinate {} {} {}", x, y, z)
+   MESSAGE_LOG("ground coordinate {} {} {}", x, y, z)
 }
 
 //***************************************************************************
@@ -2211,7 +2201,7 @@ void UsgsAstroLsSensorModel::imageToPlane(
    double&       z,
    int&          mode) const
 {
-  MESSAGE_LOG(m_logger, "Computing imageToPlane")
+  MESSAGE_LOG("Computing imageToPlane")
    //# func_description
    //  Computes ground coordinates by intersecting image ray with
    //  a plane perpendicular to the coordinate axis with the largest
@@ -2243,7 +2233,7 @@ void UsgsAstroLsSensorModel::getAdjSensorPosVel(
    double&       vy,
    double&       vz) const
 {
-  MESSAGE_LOG(m_logger, "Calculating getAdjSensorPosVel at time {}",
+  MESSAGE_LOG("Calculating getAdjSensorPosVel at time {}",
                               time)
 
    // Sensor position and velocity (4th or 8th order Lagrange).
@@ -2257,7 +2247,7 @@ void UsgsAstroLsSensorModel::getAdjSensorPosVel(
    lagrangeInterp(m_numPositions/3, &m_velocities[0], m_t0Ephem, m_dtEphem,
       time, 3, nOrder, sensVelNom);
 
-   MESSAGE_LOG(m_logger, "getAdjSensorPosVel: using {} order Lagrange",
+   MESSAGE_LOG("getAdjSensorPosVel: using {} order Lagrange",
                                 nOrder)
 
    // Compute rotation matrix from ICR to ECF
@@ -2318,7 +2308,7 @@ void UsgsAstroLsSensorModel::getAdjSensorPosVel(
    zc = sensPosNom[2]
       + ecfFromIcr[6] * di + ecfFromIcr[7] * dc + ecfFromIcr[8] * dr;
 
-   MESSAGE_LOG(m_logger, "getAdjSensorPosVel: postition {} {} {}"
+   MESSAGE_LOG("getAdjSensorPosVel: postition {} {} {}"
                                 "and velocity {} {} {}",
                               xc, yc, zc, vx, vy, vz)
 }
@@ -2332,7 +2322,7 @@ std::vector<double> UsgsAstroLsSensorModel::computeDetectorView(
    const csm::EcefCoord& groundPoint,
    const std::vector<double>& adj) const
 {
-  MESSAGE_LOG(m_logger, "Computing computeDetectorView (with adjusments)"
+  MESSAGE_LOG("Computing computeDetectorView (with adjusments)"
                               "for ground point {} {} {} at time {} ",
                               groundPoint.x, groundPoint.y, groundPoint.z, time)
 
@@ -2348,7 +2338,7 @@ std::vector<double> UsgsAstroLsSensorModel::computeDetectorView(
    double bodyLookX = groundPoint.x - xc;
    double bodyLookY = groundPoint.y - yc;
    double bodyLookZ = groundPoint.z - zc;
-   MESSAGE_LOG(m_logger, "computeDetectorView: look vector {} {} {}",
+   MESSAGE_LOG("computeDetectorView: look vector {} {} {}",
                                 bodyLookX, bodyLookY, bodyLookZ)
 
    // Rotate the look vector into the camera reference frame
@@ -2367,7 +2357,7 @@ std::vector<double> UsgsAstroLsSensorModel::computeDetectorView(
    double cameraLookZ = bodyToCamera[2] * bodyLookX
                       + bodyToCamera[5] * bodyLookY
                       + bodyToCamera[8] * bodyLookZ;
-   MESSAGE_LOG(m_logger, "computeDetectorView: look vector (camrea ref frame)"
+   MESSAGE_LOG("computeDetectorView: look vector (camrea ref frame)"
                                "{} {} {}",
                                 cameraLookX, cameraLookY, cameraLookZ)
 
@@ -2385,7 +2375,7 @@ std::vector<double> UsgsAstroLsSensorModel::computeDetectorView(
    double adjustedLookZ = attCorr[2] * cameraLookX
                         + attCorr[5] * cameraLookY
                         + attCorr[8] * cameraLookZ;
-   MESSAGE_LOG(m_logger, "computeDetectorView: adjusted look vector"
+   MESSAGE_LOG("computeDetectorView: adjusted look vector"
                                "{} {} {}",
                                 adjustedLookX, adjustedLookY, adjustedLookZ)
 
@@ -2394,7 +2384,7 @@ std::vector<double> UsgsAstroLsSensorModel::computeDetectorView(
    double focalX = adjustedLookX * lookScale;
    double focalY = adjustedLookY * lookScale;
 
-   MESSAGE_LOG(m_logger, "computeDetectorView: focal plane coordinates"
+   MESSAGE_LOG("computeDetectorView: focal plane coordinates"
                          "x:{} y:{} scale:{}",
                          focalX, focalY, lookScale)
 
@@ -2423,14 +2413,14 @@ void UsgsAstroLsSensorModel::computeLinearApproximation(
 
       if (ip.samp < 0.0)     ip.samp = 0.0;
       if (ip.samp > numCols) ip.samp = numCols;
-      MESSAGE_LOG(m_logger, "Computing computeLinearApproximation"
+      MESSAGE_LOG("Computing computeLinearApproximation"
                                   "with linear approximation")
    }
    else
    {
       ip.line = m_nLines / 2.0;
       ip.samp = m_nSamples / 2.0;
-      MESSAGE_LOG(m_logger, "Computing computeLinearApproximation"
+      MESSAGE_LOG("Computing computeLinearApproximation"
                                   "nonlinear approx line/2 and sample/2")
    }
 }
@@ -2441,7 +2431,7 @@ void UsgsAstroLsSensorModel::computeLinearApproximation(
 //***************************************************************************
 void UsgsAstroLsSensorModel::setLinearApproximation()
 {
-  MESSAGE_LOG(m_logger, "Calculating setLinearApproximation")
+  MESSAGE_LOG("Calculating setLinearApproximation")
   double u_factors[4] = { 0.0, 0.0, 1.0, 1.0 };
   double v_factors[4] = { 0.0, 1.0, 0.0, 1.0 };
 
@@ -2453,14 +2443,14 @@ void UsgsAstroLsSensorModel::setLinearApproximation()
         m_majorAxis, m_minorAxis, desired_precision);
   if (std::isnan(height))
   {
-    MESSAGE_LOG(m_logger, "setLinearApproximation: computeElevation of"
+    MESSAGE_LOG("setLinearApproximation: computeElevation of"
                                 "reference point {} {} {} with desired precision"
                                 "{} returned nan height; nonlinear",
                                 refPt.x, refPt.y, refPt.z, desired_precision)
     _linear = false;
     return;
   }
-  MESSAGE_LOG(m_logger, "setLinearApproximation: computeElevation of"
+  MESSAGE_LOG("setLinearApproximation: computeElevation of"
                               "reference point {} {} {} with desired precision"
                               "{} returned {} height",
                               refPt.x, refPt.y, refPt.z, desired_precision, height)
@@ -2526,7 +2516,7 @@ void UsgsAstroLsSensorModel::setLinearApproximation()
 
   if (fabs(denom) < 1.0e-8) // can not get derivatives this way
   {
-    MESSAGE_LOG(m_logger, "setLinearApproximation: determinant3x3 of"
+    MESSAGE_LOG("setLinearApproximation: determinant3x3 of"
                                 "matrix of partials is {}; nonlinear",
                                 denom)
     _linear = false;
@@ -2571,7 +2561,7 @@ void UsgsAstroLsSensorModel::setLinearApproximation()
   _v0 = -gp[0].x * _dv_dx - gp[0].y * _dv_dy - gp[0].z * _dv_dz;
 
   _linear = true;
-  MESSAGE_LOG(m_logger, "Completed setLinearApproximation")
+  MESSAGE_LOG("Completed setLinearApproximation")
 }
 
 //***************************************************************************
@@ -2589,22 +2579,27 @@ double UsgsAstroLsSensorModel::determinant3x3(double mat[9]) const
 //***************************************************************************
 // UsgsAstroLineScannerSensorModel::constructStateFromIsd
 //***************************************************************************
-std::string UsgsAstroLsSensorModel::constructStateFromIsd(const std::string imageSupportData, csm::WarningList *warnings) const
+std::string UsgsAstroLsSensorModel::constructStateFromIsd(const std::string imageSupportData, csm::WarningList *warnings)
 {
-  MESSAGE_LOG(m_logger, "Constructing state from Isd")
-  // Instantiate UsgsAstroLineScanner sensor model
-  json isd = json::parse(imageSupportData);
   json state = {};
+  // Get the optional custom logger
+  state["m_logName"] = "usgscsm_logger";
+  if (m_logName != "usgscsm_logger" && m_logName != "") {
+    state["m_logName"] = m_logName;
+  }
+  MESSAGE_LOG("Constructing state from Isd")
+  // Instantiate UsgsAstroLineScanner sensor model
+  ale::Isd stateIsd(imageSupportData);
 
   csm::WarningList* parsingWarnings = new csm::WarningList;
 
   int num_params = NUM_PARAMETERS;
 
-  state["m_modelName"] = getSensorModelName(isd, parsingWarnings);
-  state["m_imageIdentifier"] = getImageId(isd, parsingWarnings);
-  state["m_sensorName"] = getSensorName(isd, parsingWarnings);
-  state["m_platformName"] = getPlatformName(isd, parsingWarnings);
-  MESSAGE_LOG(m_logger, "m_modelName: {} "
+  state["m_modelName"] = stateIsd.usgscsm_name_model;
+  state["m_imageIdentifier"] = stateIsd.image_id;
+  state["m_sensorName"] = stateIsd.name_sensor;
+  state["m_platformName"] = stateIsd.name_platform;
+  MESSAGE_LOG("m_modelName: {} "
                         "m_imageIdentifier: {} "
                         "m_sensorName: {} "
                         "m_platformName: {} ",
@@ -2613,40 +2608,40 @@ std::string UsgsAstroLsSensorModel::constructStateFromIsd(const std::string imag
                         state["m_sensorName"].dump(),
                         state["m_platformName"].dump())
 
-  state["m_focalLength"] = getFocalLength(isd, parsingWarnings);
-  MESSAGE_LOG(m_logger, "m_focalLength: {} ", state["m_focalLength"].dump())
+  state["m_focalLength"] = stateIsd.focal_length;
+  MESSAGE_LOG("m_focalLength: {} ", state["m_focalLength"].dump())
 
-  state["m_nLines"] = getTotalLines(isd, parsingWarnings);
-  state["m_nSamples"] = getTotalSamples(isd, parsingWarnings);
-  MESSAGE_LOG(m_logger, "m_nLines: {} "
+  state["m_nLines"] = stateIsd.image_lines;
+  state["m_nSamples"] = stateIsd.image_samples;
+  MESSAGE_LOG("m_nLines: {} "
                         "m_nSamples: {} ",
                         state["m_nLines"].dump(), state["m_nSamples"].dump())
 
-  state["m_iTransS"] = getFocal2PixelSamples(isd, parsingWarnings);
-  state["m_iTransL"] = getFocal2PixelLines(isd, parsingWarnings);
-  MESSAGE_LOG(m_logger, "m_iTransS: {} "
+  state["m_iTransS"] = stateIsd.focal2pixel_sample;
+  state["m_iTransL"] = stateIsd.focal2pixel_line;
+  MESSAGE_LOG("m_iTransS: {} "
                         "m_iTransL: {} ",
                         state["m_iTransS"].dump(), state["m_iTransL"].dump())
 
   state["m_platformFlag"] = 1;
   state["m_ikCode"] = 0;
   state["m_zDirection"] = 1;
-  MESSAGE_LOG(m_logger, "m_platformFlag: {} "
+  MESSAGE_LOG("m_platformFlag: {} "
                         "m_ikCode: {} "
                         "m_zDirection: {} ",
                         state["m_platformFlag"].dump(), state["m_ikCode"].dump(),
                         state["m_zDirection"].dump())
 
-  state["m_distortionType"] = getDistortionModel(isd, parsingWarnings);
-  state["m_opticalDistCoeffs"] = getDistortionCoeffs(isd, parsingWarnings);
-  MESSAGE_LOG(m_logger, "m_distortionType: {} "
+  state["m_distortionType"] = getDistortionModel(stateIsd.distortion_model);
+  state["m_opticalDistCoeffs"] = stateIsd.distortion_coefficients;
+  MESSAGE_LOG("m_distortionType: {} "
                         "m_opticalDistCoeffs: {} ",
                         state["m_distortionType"].dump(),
                         state["m_opticalDistCoeffs"].dump())
 
   // Zero computed state values
   state["m_referencePointXyz"] = std::vector<double>(3, 0.0);
-  MESSAGE_LOG(m_logger, "m_referencePointXyz: {} ",
+  MESSAGE_LOG("m_referencePointXyz: {} ",
                         state["m_referencePointXyz"].dump())
 
   // sun_position and velocity are required for getIlluminationDirection
@@ -2658,37 +2653,38 @@ std::string UsgsAstroLsSensorModel::constructStateFromIsd(const std::string imag
   state["m_flyingHeight"] = 1000.0;
   state["m_halfSwath"] = 1000.0;
   state["m_halfTime"] = 10.0;
-  MESSAGE_LOG(m_logger, "m_gsd: {} "
+  MESSAGE_LOG("m_gsd: {} "
                         "m_flyingHeight: {} "
                         "m_halfSwath: {} "
                         "m_halfTime: {} ",
                         state["m_gsd"].dump(), state["m_flyingHeight"].dump(),
                         state["m_halfSwath"].dump(), state["m_halfTime"].dump())
 
-  state["m_centerEphemerisTime"] = getCenterTime(isd, parsingWarnings);
-  state["m_startingEphemerisTime"] = getStartingTime(isd, parsingWarnings);
-  MESSAGE_LOG(m_logger, "m_centerEphemerisTime: {} "
+  state["m_centerEphemerisTime"] = stateIsd.center_ephemeris_time;
+  state["m_startingEphemerisTime"] = stateIsd.starting_ephemeris_time;
+  MESSAGE_LOG("m_centerEphemerisTime: {} "
                         "m_startingEphemerisTime: {} ",
                         state["m_centerEphemerisTime"].dump(),
                         state["m_startingEphemerisTime"].dump())
 
-  state["m_intTimeLines"] = getIntegrationStartLines(isd, parsingWarnings);
-  state["m_intTimeStartTimes"] = getIntegrationStartTimes(isd, parsingWarnings);
-  state["m_intTimes"] = getIntegrationTimes(isd, parsingWarnings);
-  MESSAGE_LOG(m_logger, "m_intTimeLines: {} "
+  std::vector<std::vector<double>> lineScanRate = stateIsd.line_scan_rate;
+  state["m_intTimeLines"] = getIntegrationStartLines(lineScanRate, parsingWarnings);
+  state["m_intTimeStartTimes"] = getIntegrationStartTimes(lineScanRate, parsingWarnings);
+  state["m_intTimes"] = getIntegrationTimes(lineScanRate, parsingWarnings);
+  MESSAGE_LOG("m_intTimeLines: {} "
                         "m_intTimeStartTimes: {} "
                         "m_intTimes: {} ",
                         state["m_intTimeLines"].dump(),
                         state["m_intTimeStartTimes"].dump(),
                         state["m_intTimes"].dump())
 
-  state["m_detectorSampleSumming"] = getSampleSumming(isd, parsingWarnings);
-  state["m_detectorLineSumming"] = getLineSumming(isd, parsingWarnings);
-  state["m_startingDetectorSample"] = getDetectorStartingSample(isd, parsingWarnings);
-  state["m_startingDetectorLine"] = getDetectorStartingLine(isd, parsingWarnings);
-  state["m_detectorSampleOrigin"] = getDetectorCenterSample(isd, parsingWarnings);
-  state["m_detectorLineOrigin"] = getDetectorCenterLine(isd, parsingWarnings);
-  MESSAGE_LOG(m_logger, "m_detectorSampleSumming: {} "
+  state["m_detectorSampleSumming"] = stateIsd.detector_sample_summing;
+  state["m_detectorLineSumming"] = stateIsd.detector_line_summing;
+  state["m_startingDetectorSample"] = stateIsd.starting_detector_sample;
+  state["m_startingDetectorLine"] = stateIsd.starting_detector_line;
+  state["m_detectorSampleOrigin"] = stateIsd.detector_center_sample;
+  state["m_detectorLineOrigin"] = stateIsd.detector_center_line;
+  MESSAGE_LOG("m_detectorSampleSumming: {} "
                         "m_detectorLineSumming: {}"
                         "m_startingDetectorSample: {} "
                         "m_startingDetectorLine: {} "
@@ -2704,8 +2700,8 @@ std::string UsgsAstroLsSensorModel::constructStateFromIsd(const std::string imag
 
   // These are exlusive to LineScanners, leave them here for now.
   try {
-    state["m_dtEphem"] = isd.at("dt_ephemeris");
-    MESSAGE_LOG(m_logger, "m_dtEphem: {} ", state["m_dtEphem"].dump())
+    state["m_dtEphem"] = (ephemTime[ephemTime.size() - 1] - ephemTime[0]) / (ephemTime.size() - 1);
+    MESSAGE_LOG("m_dtEphem: {} ", state["m_dtEphem"].dump())
   }
   catch(...) {
     parsingWarnings->push_back(
@@ -2713,12 +2709,12 @@ std::string UsgsAstroLsSensorModel::constructStateFromIsd(const std::string imag
         csm::Warning::DATA_NOT_AVAILABLE,
         "dt_ephemeris not in ISD",
         "UsgsAstroFrameSensorModel::constructStateFromIsd()"));
-    MESSAGE_LOG(m_logger, "m_dtEphem not in ISD")
+    MESSAGE_LOG("m_dtEphem not in ISD")
   }
 
   try {
-    state["m_t0Ephem"] = isd.at("t0_ephemeris");
-    MESSAGE_LOG(m_logger, "t0_ephemeris: {}", state["m_t0Ephem"].dump())
+    state["m_t0Ephem"] = ephemTime[0] - stateIsd.center_ephemeris_time;
+    MESSAGE_LOG("t0_ephemeris: {}", state["m_t0Ephem"].dump())
   }
   catch(...) {
     parsingWarnings->push_back(
@@ -2726,12 +2722,12 @@ std::string UsgsAstroLsSensorModel::constructStateFromIsd(const std::string imag
         csm::Warning::DATA_NOT_AVAILABLE,
         "t0_ephemeris not in ISD",
         "UsgsAstroFrameSensorModel::constructStateFromIsd()"));
-    MESSAGE_LOG(m_logger, "t0_ephemeris not in ISD")
+    MESSAGE_LOG("t0_ephemeris not in ISD")
   }
 
   try{
-    state["m_dtQuat"] =  isd.at("dt_quaternion");
-    MESSAGE_LOG(m_logger, "dt_quaternion: {}", state["m_dtQuat"].dump())
+    state["m_dtQuat"] =  (ephemTime[ephemTime.size() - 1] - ephemTime[0]) / (ephemTime.size() - 1);
+    MESSAGE_LOG("dt_quaternion: {}", state["m_dtQuat"].dump())
   }
   catch(...) {
     parsingWarnings->push_back(
@@ -2739,12 +2735,12 @@ std::string UsgsAstroLsSensorModel::constructStateFromIsd(const std::string imag
         csm::Warning::DATA_NOT_AVAILABLE,
         "dt_quaternion not in ISD",
         "UsgsAstroFrameSensorModel::constructStateFromIsd()"));
-    MESSAGE_LOG(m_logger, "dt_quaternion not in ISD")
+    MESSAGE_LOG("dt_quaternion not in ISD")
   }
 
   try{
-    state["m_t0Quat"] =  isd.at("t0_quaternion");
-    MESSAGE_LOG(m_logger, "m_t0Quat: {}", state["m_t0Quat"].dump())
+    state["m_t0Quat"] =  ephemTime[0] - stateIsd.center_ephemeris_time;
+    MESSAGE_LOG("m_t0Quat: {}", state["m_t0Quat"].dump())
   }
   catch(...) {
     parsingWarnings->push_back(
@@ -2752,52 +2748,52 @@ std::string UsgsAstroLsSensorModel::constructStateFromIsd(const std::string imag
         csm::Warning::DATA_NOT_AVAILABLE,
         "t0_quaternion not in ISD",
         "UsgsAstroFrameSensorModel::constructStateFromIsd()"));
-    MESSAGE_LOG(m_logger, "t0_quaternion not in ISD")
+    MESSAGE_LOG("t0_quaternion not in ISD")
   }
 
   std::vector<double> positions = getSensorPositions(isd, parsingWarnings);
   state["m_positions"] = positions;
   state["m_numPositions"] = positions.size();
-  MESSAGE_LOG(m_logger, "m_positions: {}"
+  MESSAGE_LOG("m_positions: {}"
                         "m_numPositions: {}",
                         state["m_positions"].dump(),
                         state["m_numPositions"].dump())
 
-  state["m_velocities"] = getSensorVelocities(isd, parsingWarnings);
-  MESSAGE_LOG(m_logger, "m_velocities: {}",
+  state["m_velocities"] = velocities;
+  MESSAGE_LOG("m_velocities: {}",
                         state["m_velocities"].dump())
 
   std::vector<double> quaternions = getSensorOrientations(isd, parsingWarnings);
   state["m_quaternions"] = quaternions;
   state["m_numQuaternions"] = quaternions.size();
-  MESSAGE_LOG(m_logger, "m_quaternions: {}"
+  MESSAGE_LOG("m_quaternions: {}"
                         "m_numQuaternions: {}",
                         state["m_quaternions"].dump(),
                         state["m_numQuaternions"].dump())
 
   state["m_currentParameterValue"] = std::vector<double>(NUM_PARAMETERS, 0.0);
-  MESSAGE_LOG(m_logger, "m_currentParameterValue: {}",
+  MESSAGE_LOG("m_currentParameterValue: {}",
                         state["m_currentParameterValue"].dump())
 
   // get radii
-  state["m_minorAxis"] = getSemiMinorRadius(isd, parsingWarnings);
-  state["m_majorAxis"] = getSemiMajorRadius(isd, parsingWarnings);
-  MESSAGE_LOG(m_logger, "m_minorAxis: {}"
+  state["m_minorAxis"] = stateIsd.semi_minor * 1000;
+  state["m_majorAxis"] = stateIsd.semi_major * 1000;
+  MESSAGE_LOG("m_minorAxis: {}"
                         "m_majorAxis: {}",
                         state["m_minorAxis"].dump(), state["m_majorAxis"].dump())
 
   // set identifiers
-  state["m_platformIdentifier"] = getPlatformName(isd, parsingWarnings);
-  state["m_sensorIdentifier"] = getSensorName(isd, parsingWarnings);
-  MESSAGE_LOG(m_logger, "m_platformIdentifier: {}"
+  state["m_platformIdentifier"] = stateIsd.name_platform;
+  state["m_sensorIdentifier"] = stateIsd.name_sensor;
+  MESSAGE_LOG("m_platformIdentifier: {}"
                         "m_sensorIdentifier: {}",
                         state["m_platformIdentifier"].dump(),
                         state["m_sensorIdentifier"].dump())
 
   // get reference_height
-  state["m_minElevation"] = getMinHeight(isd, parsingWarnings);
-  state["m_maxElevation"] = getMaxHeight(isd, parsingWarnings);
-  MESSAGE_LOG(m_logger, "m_minElevation: {}"
+  state["m_minElevation"] = stateIsd.min_reference_height;
+  state["m_maxElevation"] = stateIsd.max_reference_height;
+  MESSAGE_LOG("m_minElevation: {}"
                         "m_maxElevation: {}",
                         state["m_minElevation"].dump(),
                         state["m_maxElevation"].dump())
@@ -2808,9 +2804,6 @@ std::string UsgsAstroLsSensorModel::constructStateFromIsd(const std::string imag
   for (int i = 0; i < NUM_PARAMETERS; i++) {
    state["m_covariance"][i * NUM_PARAMETERS + i] = 1.0;
   }
-
-  // Get the optional logging file
-  state["m_logFile"] = getLogFile(isd);
 
   if (!parsingWarnings->empty()) {
     if (warnings) {
@@ -2835,14 +2828,14 @@ std::string UsgsAstroLsSensorModel::constructStateFromIsd(const std::string imag
 //***************************************************************************
 // UsgsAstroLineScannerSensorModel::getLogger
 //***************************************************************************
-std::shared_ptr<spdlog::logger> UsgsAstroLsSensorModel::getLogger() {
-  // MESSAGE_LOG(m_logger, "Getting log pointer, logger is {}",
+std::string UsgsAstroLsSensorModel::getLogger() {
+  // MESSAGE_LOG("Getting log pointer, logger is {}",
   //                             m_logger)
-  return m_logger;
+  return m_logName;
 }
 
-void UsgsAstroLsSensorModel::setLogger(std::shared_ptr<spdlog::logger> logger) {
-  m_logger = logger;
+void UsgsAstroLsSensorModel::setLogger(std::string logName) {
+  m_logName = logName;
 }
 
 

--- a/src/UsgsAstroLsSensorModel.cpp
+++ b/src/UsgsAstroLsSensorModel.cpp
@@ -2589,55 +2589,55 @@ std::string UsgsAstroLsSensorModel::constructStateFromIsd(const std::string imag
   }
   MESSAGE_LOG("Constructing state from Isd")
   // Instantiate UsgsAstroLineScanner sensor model
-  ale::Isd stateIsd(imageSupportData);
+  json isd = json::parse(imageSupportData);
 
   csm::WarningList* parsingWarnings = new csm::WarningList;
 
   int num_params = NUM_PARAMETERS;
 
-  state["m_modelName"] = stateIsd.usgscsm_name_model;
-  state["m_imageIdentifier"] = stateIsd.image_id;
-  state["m_sensorName"] = stateIsd.name_sensor;
-  state["m_platformName"] = stateIsd.name_platform;
+  state["m_modelName"] = getSensorModelName(isd, parsingWarnings);
+  state["m_imageIdentifier"] = getImageId(isd, parsingWarnings);
+  state["m_sensorName"] = getSensorName(isd, parsingWarnings);
+  state["m_platformName"] = getPlatformName(isd, parsingWarnings);
   MESSAGE_LOG("m_modelName: {} "
-                        "m_imageIdentifier: {} "
-                        "m_sensorName: {} "
-                        "m_platformName: {} ",
-                        state["m_modelName"].dump(),
-                        state["m_imageIdentifier"].dump(),
-                        state["m_sensorName"].dump(),
-                        state["m_platformName"].dump())
+              "m_imageIdentifier: {} "
+              "m_sensorName: {} "
+              "m_platformName: {} ",
+              state["m_modelName"].dump(),
+              state["m_imageIdentifier"].dump(),
+              state["m_sensorName"].dump(),
+              state["m_platformName"].dump())
 
-  state["m_focalLength"] = stateIsd.focal_length;
+  state["m_focalLength"] = getFocalLength(isd, parsingWarnings);
   MESSAGE_LOG("m_focalLength: {} ", state["m_focalLength"].dump())
 
-  state["m_nLines"] = stateIsd.image_lines;
-  state["m_nSamples"] = stateIsd.image_samples;
+  state["m_nLines"] = getTotalLines(isd, parsingWarnings);
+  state["m_nSamples"] = getTotalSamples(isd, parsingWarnings);
   MESSAGE_LOG("m_nLines: {} "
-                        "m_nSamples: {} ",
-                        state["m_nLines"].dump(), state["m_nSamples"].dump())
+              "m_nSamples: {} ",
+              state["m_nLines"].dump(), state["m_nSamples"].dump())
 
-  state["m_iTransS"] = stateIsd.focal2pixel_sample;
-  state["m_iTransL"] = stateIsd.focal2pixel_line;
+  state["m_iTransS"] = getFocal2PixelSamples(isd, parsingWarnings);
+  state["m_iTransL"] = getFocal2PixelLines(isd, parsingWarnings);
   MESSAGE_LOG("m_iTransS: {} "
-                        "m_iTransL: {} ",
-                        state["m_iTransS"].dump(), state["m_iTransL"].dump())
+              "m_iTransL: {} ",
+              state["m_iTransS"].dump(), state["m_iTransL"].dump())
 
   state["m_platformFlag"] = 1;
   state["m_ikCode"] = 0;
   state["m_zDirection"] = 1;
   MESSAGE_LOG("m_platformFlag: {} "
-                        "m_ikCode: {} "
-                        "m_zDirection: {} ",
-                        state["m_platformFlag"].dump(), state["m_ikCode"].dump(),
-                        state["m_zDirection"].dump())
+              "m_ikCode: {} "
+              "m_zDirection: {} ",
+              state["m_platformFlag"].dump(), state["m_ikCode"].dump(),
+              state["m_zDirection"].dump())
 
-  state["m_distortionType"] = getDistortionModel(stateIsd.distortion_model);
-  state["m_opticalDistCoeffs"] = stateIsd.distortion_coefficients;
+  state["m_distortionType"] = getDistortionModel(isd, parsingWarnings);
+  state["m_opticalDistCoeffs"] = getDistortionCoeffs(isd, parsingWarnings);
   MESSAGE_LOG("m_distortionType: {} "
-                        "m_opticalDistCoeffs: {} ",
-                        state["m_distortionType"].dump(),
-                        state["m_opticalDistCoeffs"].dump())
+              "m_opticalDistCoeffs: {} ",
+              state["m_distortionType"].dump(),
+              state["m_opticalDistCoeffs"].dump())
 
   // Zero computed state values
   state["m_referencePointXyz"] = std::vector<double>(3, 0.0);
@@ -2654,23 +2654,22 @@ std::string UsgsAstroLsSensorModel::constructStateFromIsd(const std::string imag
   state["m_halfSwath"] = 1000.0;
   state["m_halfTime"] = 10.0;
   MESSAGE_LOG("m_gsd: {} "
-                        "m_flyingHeight: {} "
-                        "m_halfSwath: {} "
-                        "m_halfTime: {} ",
-                        state["m_gsd"].dump(), state["m_flyingHeight"].dump(),
-                        state["m_halfSwath"].dump(), state["m_halfTime"].dump())
+              "m_flyingHeight: {} "
+              "m_halfSwath: {} "
+              "m_halfTime: {} ",
+              state["m_gsd"].dump(), state["m_flyingHeight"].dump(),
+              state["m_halfSwath"].dump(), state["m_halfTime"].dump())
 
-  state["m_centerEphemerisTime"] = stateIsd.center_ephemeris_time;
-  state["m_startingEphemerisTime"] = stateIsd.starting_ephemeris_time;
+  state["m_centerEphemerisTime"] = getCenterTime(isd, parsingWarnings);
+  state["m_startingEphemerisTime"] = getStartingTime(isd, parsingWarnings);
   MESSAGE_LOG("m_centerEphemerisTime: {} "
-                        "m_startingEphemerisTime: {} ",
-                        state["m_centerEphemerisTime"].dump(),
-                        state["m_startingEphemerisTime"].dump())
+              "m_startingEphemerisTime: {} ",
+              state["m_centerEphemerisTime"].dump(),
+              state["m_startingEphemerisTime"].dump())
 
-  std::vector<std::vector<double>> lineScanRate = stateIsd.line_scan_rate;
-  state["m_intTimeLines"] = getIntegrationStartLines(lineScanRate, parsingWarnings);
-  state["m_intTimeStartTimes"] = getIntegrationStartTimes(lineScanRate, parsingWarnings);
-  state["m_intTimes"] = getIntegrationTimes(lineScanRate, parsingWarnings);
+  state["m_intTimeLines"] = getIntegrationStartLines(isd, parsingWarnings);
+  state["m_intTimeStartTimes"] = getIntegrationStartTimes(isd, parsingWarnings);
+  state["m_intTimes"] = getIntegrationTimes(isd, parsingWarnings);
   MESSAGE_LOG("m_intTimeLines: {} "
                         "m_intTimeStartTimes: {} "
                         "m_intTimes: {} ",
@@ -2678,29 +2677,29 @@ std::string UsgsAstroLsSensorModel::constructStateFromIsd(const std::string imag
                         state["m_intTimeStartTimes"].dump(),
                         state["m_intTimes"].dump())
 
-  state["m_detectorSampleSumming"] = stateIsd.detector_sample_summing;
-  state["m_detectorLineSumming"] = stateIsd.detector_line_summing;
-  state["m_startingDetectorSample"] = stateIsd.starting_detector_sample;
-  state["m_startingDetectorLine"] = stateIsd.starting_detector_line;
-  state["m_detectorSampleOrigin"] = stateIsd.detector_center_sample;
-  state["m_detectorLineOrigin"] = stateIsd.detector_center_line;
+  state["m_detectorSampleSumming"] = getSampleSumming(isd, parsingWarnings);
+  state["m_detectorLineSumming"] = getLineSumming(isd, parsingWarnings);
+  state["m_startingDetectorSample"] = getDetectorStartingSample(isd, parsingWarnings);
+  state["m_startingDetectorLine"] = getDetectorStartingLine(isd, parsingWarnings);
+  state["m_detectorSampleOrigin"] = getDetectorCenterSample(isd, parsingWarnings);
+  state["m_detectorLineOrigin"] = getDetectorCenterLine(isd, parsingWarnings);
   MESSAGE_LOG("m_detectorSampleSumming: {} "
-                        "m_detectorLineSumming: {}"
-                        "m_startingDetectorSample: {} "
-                        "m_startingDetectorLine: {} "
-                        "m_detectorSampleOrigin: {} "
-                        "m_detectorLineOrigin: {} ",
-                        state["m_detectorSampleSumming"].dump(),
-                        state["m_detectorLineSumming"].dump(),
-                        state["m_startingDetectorSample"].dump(),
-                        state["m_startingDetectorLine"].dump(),
-                        state["m_detectorSampleOrigin"].dump(),
-                        state["m_detectorLineOrigin"].dump())
+              "m_detectorLineSumming: {}"
+              "m_startingDetectorSample: {} "
+              "m_startingDetectorLine: {} "
+              "m_detectorSampleOrigin: {} "
+              "m_detectorLineOrigin: {} ",
+              state["m_detectorSampleSumming"].dump(),
+              state["m_detectorLineSumming"].dump(),
+              state["m_startingDetectorSample"].dump(),
+              state["m_startingDetectorLine"].dump(),
+              state["m_detectorSampleOrigin"].dump(),
+              state["m_detectorLineOrigin"].dump())
 
 
   // These are exlusive to LineScanners, leave them here for now.
   try {
-    state["m_dtEphem"] = (ephemTime[ephemTime.size() - 1] - ephemTime[0]) / (ephemTime.size() - 1);
+    state["m_dtEphem"] = isd.at("dt_ephemeris");
     MESSAGE_LOG("m_dtEphem: {} ", state["m_dtEphem"].dump())
   }
   catch(...) {
@@ -2713,7 +2712,7 @@ std::string UsgsAstroLsSensorModel::constructStateFromIsd(const std::string imag
   }
 
   try {
-    state["m_t0Ephem"] = ephemTime[0] - stateIsd.center_ephemeris_time;
+    state["m_t0Ephem"] = isd.at("t0_ephemeris");
     MESSAGE_LOG("t0_ephemeris: {}", state["m_t0Ephem"].dump())
   }
   catch(...) {
@@ -2726,7 +2725,7 @@ std::string UsgsAstroLsSensorModel::constructStateFromIsd(const std::string imag
   }
 
   try{
-    state["m_dtQuat"] =  (ephemTime[ephemTime.size() - 1] - ephemTime[0]) / (ephemTime.size() - 1);
+    state["m_dtQuat"] = isd.at("dt_quaternion");
     MESSAGE_LOG("dt_quaternion: {}", state["m_dtQuat"].dump())
   }
   catch(...) {
@@ -2739,7 +2738,7 @@ std::string UsgsAstroLsSensorModel::constructStateFromIsd(const std::string imag
   }
 
   try{
-    state["m_t0Quat"] =  ephemTime[0] - stateIsd.center_ephemeris_time;
+    state["m_t0Quat"] =  isd.at("t0_quaternion");
     MESSAGE_LOG("m_t0Quat: {}", state["m_t0Quat"].dump())
   }
   catch(...) {
@@ -2755,48 +2754,48 @@ std::string UsgsAstroLsSensorModel::constructStateFromIsd(const std::string imag
   state["m_positions"] = positions;
   state["m_numPositions"] = positions.size();
   MESSAGE_LOG("m_positions: {}"
-                        "m_numPositions: {}",
-                        state["m_positions"].dump(),
-                        state["m_numPositions"].dump())
+              "m_numPositions: {}",
+              state["m_positions"].dump(),
+              state["m_numPositions"].dump())
 
-  state["m_velocities"] = velocities;
+  state["m_velocities"] = getSensorVelocities(isd, parsingWarnings);
   MESSAGE_LOG("m_velocities: {}",
-                        state["m_velocities"].dump())
+              state["m_velocities"].dump())
 
   std::vector<double> quaternions = getSensorOrientations(isd, parsingWarnings);
   state["m_quaternions"] = quaternions;
   state["m_numQuaternions"] = quaternions.size();
   MESSAGE_LOG("m_quaternions: {}"
-                        "m_numQuaternions: {}",
-                        state["m_quaternions"].dump(),
-                        state["m_numQuaternions"].dump())
+              "m_numQuaternions: {}",
+              state["m_quaternions"].dump(),
+              state["m_numQuaternions"].dump())
 
   state["m_currentParameterValue"] = std::vector<double>(NUM_PARAMETERS, 0.0);
   MESSAGE_LOG("m_currentParameterValue: {}",
-                        state["m_currentParameterValue"].dump())
+              state["m_currentParameterValue"].dump())
 
   // get radii
-  state["m_minorAxis"] = stateIsd.semi_minor * 1000;
-  state["m_majorAxis"] = stateIsd.semi_major * 1000;
+  state["m_minorAxis"] = getSemiMinorRadius(isd, parsingWarnings);
+  state["m_majorAxis"] = getSemiMajorRadius(isd, parsingWarnings);
   MESSAGE_LOG("m_minorAxis: {}"
-                        "m_majorAxis: {}",
-                        state["m_minorAxis"].dump(), state["m_majorAxis"].dump())
+              "m_majorAxis: {}",
+              state["m_minorAxis"].dump(), state["m_majorAxis"].dump())
 
   // set identifiers
-  state["m_platformIdentifier"] = stateIsd.name_platform;
-  state["m_sensorIdentifier"] = stateIsd.name_sensor;
+  state["m_platformIdentifier"] = getPlatformName(isd, parsingWarnings);
+  state["m_sensorIdentifier"] = getSensorName(isd, parsingWarnings);
   MESSAGE_LOG("m_platformIdentifier: {}"
-                        "m_sensorIdentifier: {}",
-                        state["m_platformIdentifier"].dump(),
-                        state["m_sensorIdentifier"].dump())
+              "m_sensorIdentifier: {}",
+              state["m_platformIdentifier"].dump(),
+              state["m_sensorIdentifier"].dump())
 
   // get reference_height
-  state["m_minElevation"] = stateIsd.min_reference_height;
-  state["m_maxElevation"] = stateIsd.max_reference_height;
+  state["m_minElevation"] = getMinHeight(isd, parsingWarnings);
+  state["m_maxElevation"] = getMaxHeight(isd, parsingWarnings);
   MESSAGE_LOG("m_minElevation: {}"
-                        "m_maxElevation: {}",
-                        state["m_minElevation"].dump(),
-                        state["m_maxElevation"].dump())
+              "m_maxElevation: {}",
+              state["m_minElevation"].dump(),
+              state["m_maxElevation"].dump())
 
   // Default to identity covariance
   state["m_covariance"] =

--- a/src/UsgsAstroPlugin.cpp
+++ b/src/UsgsAstroPlugin.cpp
@@ -279,7 +279,7 @@ csm::Model *UsgsAstroPlugin::constructModelFromISD(const csm::Isd &imageSupportD
       UsgsAstroFrameSensorModel *model =  new UsgsAstroFrameSensorModel();
       try {
         model->replaceModelState(model->constructStateFromIsd(stringIsd, warnings));
-        std::shared_ptr<spdlog::logger> logger = spdlog::get(model->getLogger());
+        std::shared_ptr<spdlog::logger> logger = model->getLogger();
         if (logger) {
           logger->info("Constructed model: {}", modelName);
         }

--- a/src/UsgsAstroPlugin.cpp
+++ b/src/UsgsAstroPlugin.cpp
@@ -38,14 +38,17 @@ const UsgsAstroPlugin UsgsAstroPlugin::m_registeredPlugin;
 UsgsAstroPlugin::UsgsAstroPlugin() {
 
   // Build and register the USGSCSM logger on pluggin creation
-  std::string logFile = getenv("ALE_LOG_FILE");
-  if (logFile != "") {
-    std::shared_ptr<spdlog::logger> logger = spdlog::get("usgscsm_logger");
-    if (!logger) {
-      logger = spdlog::basic_logger_mt("usgscsm_logger", logFile);
-      try {
-        spdlog::register_logger(logger);
-      } catch (...) {}
+  char * logFilePtr = getenv("ALE_LOG_FILE");
+  if (logFilePtr != NULL) {
+    std::string logFile(logFilePtr);
+    if (logFile != "") {
+      std::shared_ptr<spdlog::logger> logger = spdlog::get("usgscsm_logger");
+      if (!logger) {
+        logger = spdlog::basic_logger_mt("usgscsm_logger", logFile);
+        try {
+          spdlog::register_logger(logger);
+        } catch (...) {}
+      }
     }
   }
 }

--- a/src/UsgsAstroPlugin.cpp
+++ b/src/UsgsAstroPlugin.cpp
@@ -39,15 +39,15 @@ UsgsAstroPlugin::UsgsAstroPlugin() {
 
   // Build and register the USGSCSM logger on pluggin creation
   char * logFilePtr = getenv("ALE_LOG_FILE");
+
   if (logFilePtr != NULL) {
     std::string logFile(logFilePtr);
+
     if (logFile != "") {
       std::shared_ptr<spdlog::logger> logger = spdlog::get("usgscsm_logger");
+
       if (!logger) {
-        logger = spdlog::basic_logger_mt("usgscsm_logger", logFile);
-        try {
-          spdlog::register_logger(logger);
-        } catch (...) {}
+        std::shared_ptr<spdlog::logger> new_logger = spdlog::basic_logger_mt("usgscsm_logger", logFile);
       }
     }
   }

--- a/tests/Fixtures.h
+++ b/tests/Fixtures.h
@@ -90,7 +90,10 @@ class FrameSensorModelLogging : public ::testing::Test {
          // logger name collisions. Use the sensor model's memory addresss.
          std::uintptr_t sensorId = reinterpret_cast<std::uintptr_t>(sensorModel);
          auto logger = std::make_shared<spdlog::logger>(std::to_string(sensorId), ostream_sink);
-         sensorModel->setLogger(logger);
+         try {
+           spdlog::register_logger(logger);
+         } catch (...) {}
+         sensorModel->setLogger(std::to_string(sensorId));
       }
 
       void TearDown() override {

--- a/tests/Fixtures.h
+++ b/tests/Fixtures.h
@@ -90,14 +90,17 @@ class FrameSensorModelLogging : public ::testing::Test {
          // logger name collisions. Use the sensor model's memory addresss.
          std::uintptr_t sensorId = reinterpret_cast<std::uintptr_t>(sensorModel);
          auto logger = std::make_shared<spdlog::logger>(std::to_string(sensorId), ostream_sink);
-         try {
-           spdlog::register_logger(logger);
-         } catch (...) {}
+         spdlog::register_logger(logger);
+         
          sensorModel->setLogger(std::to_string(sensorId));
       }
 
       void TearDown() override {
          if (sensorModel) {
+            // Remove the logger from the registry for other tests
+            std::uintptr_t sensorId = reinterpret_cast<std::uintptr_t>(sensorModel);
+            spdlog::drop(std::to_string(sensorId));
+
             delete sensorModel;
             sensorModel = NULL;
          }


### PR DESCRIPTION
Changes how logging is handled in both the Framer and Line Scanner sensor models. The plugin now handles logger creation and each sensor model will only log if this logger is present.

### Detail

Whenever a plugin is in instantiated, the plugin will also create a logger called `usgscsm_logger` which will have a sink defined in the environment variable `ALE_LOG_FILE`. The two sensor models write to this logger by default.

If you want to adjust where either of the sensor models write to, you'll need to create a new spd logger, register said logger, and update the name of the logger for the sensor model you are working with. As such this can only really be done on the C++ side but the output location of your log can be changed on the fly by changing `ALE_LOG_FILE`.

A few things to potentially discuss:

Do we want to be able to split the loggers more dynamically rather than everything be dumped into one output location?

Do we just create a config that has a separate logger and log output location that can be parsed at run time for each sensor model?
