### PR TITLE
Added no sharing criteria

### DIFF
--- a/src/UsgsAstroFrameSensorModel.cpp
+++ b/src/UsgsAstroFrameSensorModel.cpp
@@ -525,7 +525,7 @@ UsgsAstroFrameSensorModel::computeAllSensorPartials(
       groundPt.x, groundPt.y, groundPt.z, imagePt.line, imagePt.samp, pset,
       desiredPrecision);
 
-  return RasterGM::computeAllSensorPartials(imagePt, groundPt, pset, desiredPrecision, 
+  return RasterGM::computeAllSensorPartials(imagePt, groundPt, pset, desiredPrecision,
                                             achievedPrecision, warnings);
 }
 
@@ -1125,12 +1125,9 @@ csm::SharingCriteria UsgsAstroFrameSensorModel::getParameterSharingCriteria(
     int index) const {
   MESSAGE_LOG(
       "Checking sharing criteria for parameter {}. "
-      "Sharing is not supported, throwing exception",
+      "Sharing is not supported.",
       index);
-  // Parameter sharing is not supported for this sensor,
-  // all indices are out of range
-  throw csm::Error(csm::Error::INDEX_OUT_OF_RANGE, "Index out of range.",
-                   "UsgsAstroLsSensorModel::getParameterSharingCriteria");
+  return csm::SharingCriteria();
 }
 
 double UsgsAstroFrameSensorModel::getParameterValue(int index) const {

--- a/src/UsgsAstroLsSensorModel.cpp
+++ b/src/UsgsAstroLsSensorModel.cpp
@@ -1568,12 +1568,9 @@ csm::SharingCriteria UsgsAstroLsSensorModel::getParameterSharingCriteria(
     int index) const {
   MESSAGE_LOG(
       "Checking sharing criteria for parameter {}. "
-      "Sharing is not supported, throwing exception",
+      "Sharing is not supported.",
       index);
-  // Parameter sharing is not supported for this sensor,
-  // all indices are out of range
-  throw csm::Error(csm::Error::INDEX_OUT_OF_RANGE, "Index out of range.",
-                   "UsgsAstroLsSensorModel::getParameterSharingCriteria");
+  return csm::SharingCriteria();
 }
 
 //***************************************************************************

--- a/tests/FrameCameraTests.cpp
+++ b/tests/FrameCameraTests.cpp
@@ -624,11 +624,7 @@ TEST_F(FrameSensorModelLogging, IsParameterShareable) {
 }
 
 TEST_F(FrameSensorModelLogging, GetParameterSharingCriteria) {
-  try {
-    sensorModel->getParameterSharingCriteria(0);
-  } catch (...) {
-    // Just testing logging, so do nothing, it should still log
-  }
+  sensorModel->getParameterSharingCriteria(0);
 }
 
 TEST_F(FrameSensorModelLogging, GetParameterValue) {


### PR DESCRIPTION
The linescan and framing models errored when you accessed their parameter sharing criteria. This is not what's suppose to happen when parameters are not sharable. Instead, they should return the default SharingCriteria.

This was causing the default GeometricModel::getParameter and GeometricModel::getParameters to raise an exception when they shouldn't.