### PR TITLE
Update getReferenceDateAndTime() to follow ISO8601

### DIFF
--- a/src/UsgsAstroFrameSensorModel.cpp
+++ b/src/UsgsAstroFrameSensorModel.cpp
@@ -674,9 +674,9 @@ std::string UsgsAstroFrameSensorModel::getReferenceDateAndTime() const {
   t.tm_mday = 1;
   time_t timeSinceEpoch = mktime(&t);
   time_t finalTime = ephemTime + timeSinceEpoch;
-  char buffer[16];
-  strftime(buffer, 16, "%Y%m%dT%H%M%S", localtime(&finalTime));
-  buffer[15] = '\0';
+  char buffer[22];
+  strftime(buffer, 22, "%Y-%m-%dT%H:%M:%SZ", localtime(&finalTime));
+  buffer[21] = '\0';
 
   return buffer;
 }

--- a/src/UsgsAstroLsSensorModel.cpp
+++ b/src/UsgsAstroLsSensorModel.cpp
@@ -1184,9 +1184,9 @@ std::string UsgsAstroLsSensorModel::getReferenceDateAndTime() const {
   t.tm_mday = 1;
   time_t timeSinceEpoch = mktime(&t);
   time_t finalTime = ephemTime + timeSinceEpoch;
-  char buffer[16];
-  strftime(buffer, 16, "%Y%m%dT%H%M%S", localtime(&finalTime));
-  buffer[15] = '\0';
+  char buffer[22];
+  strftime(buffer, 22, "%Y-%m-%dT%H:%M:%SZ", localtime(&finalTime));
+  buffer[21] = '\0';
 
   return buffer;
 }

--- a/src/UsgsAstroSarSensorModel.cpp
+++ b/src/UsgsAstroSarSensorModel.cpp
@@ -1045,9 +1045,9 @@ string UsgsAstroSarSensorModel::getReferenceDateAndTime() const {
   t.tm_mday = 1;
   time_t timeSinceEpoch = mktime(&t);
   time_t finalTime = ephemTime + timeSinceEpoch;
-  char buffer[16];
-  strftime(buffer, 16, "%Y%m%dT%H%M%S", localtime(&finalTime));
-  buffer[15] = '\0';
+  char buffer[22];
+  strftime(buffer, 22, "%Y-%m-%dT%H:%M:%SZ", localtime(&finalTime));
+  buffer[21] = '\0';
 
   return buffer;
 }

--- a/tests/FrameCameraTests.cpp
+++ b/tests/FrameCameraTests.cpp
@@ -736,5 +736,5 @@ TEST_F(FrameSensorModelLogging, losEllipsoidIntersect) {
 
 TEST_F(OrbitalFrameSensorModel, ReferenceDateTime) {
   std::string date = sensorModel->getReferenceDateAndTime();
-  EXPECT_EQ(date, "20000101T001640");
+  EXPECT_EQ(date, "2000-01-01T00:16:40Z");
 }

--- a/tests/LineScanCameraTests.cpp
+++ b/tests/LineScanCameraTests.cpp
@@ -241,7 +241,7 @@ TEST_F(OrbitalLineScanSensorModel, InversionReallyHigh) {
 
 TEST_F(OrbitalLineScanSensorModel, ReferenceDateTime) {
   std::string date = sensorModel->getReferenceDateAndTime();
-  EXPECT_EQ(date, "20000101T001639");
+  EXPECT_EQ(date, "2000-01-01T00:16:39Z");
 }
 
 TEST_F(TwoLineScanSensorModels, CrossCovariance) {

--- a/tests/SarTests.cpp
+++ b/tests/SarTests.cpp
@@ -131,3 +131,8 @@ TEST_F(SarSensorModel, adjustedPositionVelocity) {
   EXPECT_NEAR(adjVelocity.y, sensorVelocity.y + adjustments[4], 1e-8);
   EXPECT_NEAR(adjVelocity.z, sensorVelocity.z + adjustments[5], 1e-2);
 }
+
+TEST_F(SarSensorModel, ReferenceDateTime) {
+  std::string date = sensorModel->getReferenceDateAndTime();
+  EXPECT_EQ(date, "2000-01-01T00:00:04Z");
+}


### PR DESCRIPTION
Updates all sensor models provided by usgscsm to use ISO8601 for times output by `getReferenceDateAndTime()`, as required by the CSM specification. 

This fixes #320. 