### PR TITLE
Add the ability to apply a transform to a linescan model

### DIFF
--- a/include/usgscsm/UsgsAstroLsSensorModel.h
+++ b/include/usgscsm/UsgsAstroLsSensorModel.h
@@ -154,6 +154,12 @@ class UsgsAstroLsSensorModel : public csm::RasterGM,
 
   virtual std::string getModelState() const;
 
+  // Apply a rotation and translation to a state string. The effect is
+  // to transform the position and orientation of the camera in ECEF
+  // coordinates.
+  static void applyTransformToState(ale::Rotation const& r, ale::Vec3d const& t,
+                                    std::string& stateString);
+  
   // Set the sensor model based on the input state data
   void set(const std::string& state_data);
 
@@ -971,12 +977,6 @@ class UsgsAstroLsSensorModel : public csm::RasterGM,
   // Compute the determinant of a 3x3 matrix
   double determinant3x3(double mat[9]) const;
 
-  // Apply a rotation and translation to a state string. The effect is
-  // to transform the position and orientation of the camera in ECEF
-  // coordinates.
- static void applyTransformToState(ale::Rotation const& r, ale::Vec3d const& t,
-                                   std::string& stateString);
-  
   csm::NoCorrelationModel _no_corr_model;  // A way to report no correlation
                                            // between images is supported
   std::vector<double>

--- a/include/usgscsm/UsgsAstroLsSensorModel.h
+++ b/include/usgscsm/UsgsAstroLsSensorModel.h
@@ -971,6 +971,12 @@ class UsgsAstroLsSensorModel : public csm::RasterGM,
   // Compute the determinant of a 3x3 matrix
   double determinant3x3(double mat[9]) const;
 
+  // Apply a rotation and translation to a state string. The effect is
+  // to transform the position and orientation of the camera in ECEF
+  // coordinates.
+ void applyTransformToState(ale::Rotation const& r, ale::Vec3d const& t,
+                            std::string& stateString) const;
+  
   csm::NoCorrelationModel _no_corr_model;  // A way to report no correlation
                                            // between images is supported
   std::vector<double>

--- a/include/usgscsm/UsgsAstroLsSensorModel.h
+++ b/include/usgscsm/UsgsAstroLsSensorModel.h
@@ -974,8 +974,8 @@ class UsgsAstroLsSensorModel : public csm::RasterGM,
   // Apply a rotation and translation to a state string. The effect is
   // to transform the position and orientation of the camera in ECEF
   // coordinates.
- void applyTransformToState(ale::Rotation const& r, ale::Vec3d const& t,
-                            std::string& stateString) const;
+ static void applyTransformToState(ale::Rotation const& r, ale::Vec3d const& t,
+                                   std::string& stateString);
   
   csm::NoCorrelationModel _no_corr_model;  // A way to report no correlation
                                            // between images is supported

--- a/include/usgscsm/Utilities.h
+++ b/include/usgscsm/Utilities.h
@@ -10,6 +10,8 @@
 
 #include <nlohmann/json.hpp>
 
+#include <ale/Rotation.h>
+
 #include <Warning.h>
 #include <csm.h>
 
@@ -167,5 +169,10 @@ std::vector<double> getSensorOrientations(nlohmann::json isd,
                                           csm::WarningList *list = nullptr);
 double getWavelength(nlohmann::json isd, csm::WarningList *list = nullptr);
 nlohmann::json stateAsJson(std::string modelState);
+
+// Apply transforms to orientations and vectors
+void applyRotationToQuatVec(ale::Rotation const& r, std::vector<double> & quaternions);
+void applyRotationTranslationToXyzVec(ale::Rotation const& r, ale::Vec3d const& t,
+                                      std::vector<double> & xyz);
 
 #endif  // INCLUDE_USGSCSM_UTILITIES_H_

--- a/include/usgscsm/Utilities.h
+++ b/include/usgscsm/Utilities.h
@@ -11,6 +11,7 @@
 #include <nlohmann/json.hpp>
 
 #include <ale/Rotation.h>
+#include <ale/Vectors.h>
 
 #include <Warning.h>
 #include <csm.h>

--- a/src/UsgsAstroLsSensorModel.cpp
+++ b/src/UsgsAstroLsSensorModel.cpp
@@ -2591,7 +2591,7 @@ csm::EcefVector UsgsAstroLsSensorModel::getSunPosition(
 }
 
 void UsgsAstroLsSensorModel::applyTransformToState(ale::Rotation const& r, ale::Vec3d const& t,
-                                                   std::string& stateString) const {
+                                                   std::string& stateString) {
 
   nlohmann::json j = stateAsJson(stateString);
 
@@ -2616,5 +2616,5 @@ void UsgsAstroLsSensorModel::applyTransformToState(ale::Rotation const& r, ale::
   // where the Sun is.
 
   // Update the state string
-  stateString = getModelName() + "\n" + j.dump();
+  stateString = getModelNameFromModelState(stateString) + "\n" + j.dump();
 }

--- a/src/Utilities.cpp
+++ b/src/Utilities.cpp
@@ -1323,3 +1323,49 @@ json stateAsJson(std::string modelState) {
   }
   return json::parse(modelState.begin() + found, modelState.end());
 }
+
+// Apply a rotation to a vector of quaternions.
+void applyRotationToQuatVec(ale::Rotation const& r, std::vector<double> & quaternions) {
+  int num_quat = quaternions.size();
+  
+  for (int it = 0; it < num_quat/4; it++) {
+
+    double * q = &quaternions[4*it];
+
+    // Note that quaternion in q is stored in order x, y, z, w, while
+    // the rotation matrix wants it as w, x, y, z.
+    
+    std::vector<double> trans_q = (r * ale::Rotation(q[3], q[0], q[1], q[2])).toQuaternion();
+
+    // Modify in-place
+    q[0] = trans_q[1];
+    q[1] = trans_q[2];
+    q[2] = trans_q[3];
+    q[3] = trans_q[0];
+  }
+}
+
+// Apply a rotation and translation to a vector of xyz vectors.
+void applyRotationTranslationToXyzVec(ale::Rotation const& r, ale::Vec3d const& t,
+                                      std::vector<double> & xyz) {
+  
+  int num_xyz = xyz.size();
+  for (int it = 0; it < num_xyz/3; it++) {
+    
+    double * p = &xyz[3*it];
+
+    ale::Vec3d p_vec(p[0], p[1], p[2]);
+    
+    // Apply the rotation
+    p_vec = r(p_vec);
+
+    // Apply the translation
+    p_vec += t;
+
+    // Modify in-place
+    p[0] = p_vec.x;
+    p[1] = p_vec.y;
+    p[2] = p_vec.z;
+    
+  }
+}

--- a/tests/LineScanCameraTests.cpp
+++ b/tests/LineScanCameraTests.cpp
@@ -22,6 +22,29 @@ TEST_F(ConstVelocityLineScanSensorModel, State) {
   EXPECT_EQ(sensorModel->getModelState(), modelState);
 }
 
+// Apply the identity transform to a state
+TEST_F(ConstVelocityLineScanSensorModel, ApplyTransformToState) {
+  std::string modelState = sensorModel->getModelState();
+
+  ale::Rotation r; // identity rotation
+  ale::Vec3d t;    // zero translation
+
+  // The input state has some "-0" values which get transformed by
+  // applying the identity transform into "0", which results in the
+  // state string changing. Hence, for this test, compare the results
+  // of applying the identity transform once vs twice, which are the
+  // same.
+
+  // First application
+  UsgsAstroLsSensorModel::applyTransformToState(r, t, modelState);
+
+  // Second application
+  std::string modelState2 = modelState;
+  UsgsAstroLsSensorModel::applyTransformToState(r, t, modelState2);
+
+  EXPECT_EQ(modelState, modelState2);
+}
+
 // Fly by tests
 
 TEST_F(ConstVelocityLineScanSensorModel, Center) {


### PR DESCRIPTION
This makes it possible to apply to a linescan model state a rotation and translation, whose effect is to change the camera position and orientation in ECEF.

This is something I needed in ASP for bundle adjustment. I have a copy of this functionality over there, so I don't need this pull request for my own work, but I thought it would make sense in the linesecan model and could be used by other tools which need to modify this state. 