### PR TITLE
Bump up cmake requirement to 3.15 and fix the conda env command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ GBs.
 
 ## Build Requirements
 
-* cmake 3.10 or newer
+* cmake 3.15 or newer
 * GNU-compatible Make
-* a c++11 compliant compiler
+* a C++11 compliant compiler
 
 This repository has all of its external c++ dependencies included in it. The
 excellent header-only JSON library
@@ -65,7 +65,7 @@ be available within the source code. You can remove the googletest dependency
 by disabling the tests.
 
 ```
-conda env create -n usgscsm -f environment.yml -y
+conda env create -n usgscsm -f environment.yml
 ```
 
 ## Building USGSCSM

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - default
 
 dependencies:
-  - cmake>=3.12
+  - cmake>=3.15
   - ale
   - csm
   - nlohmann_json


### PR DESCRIPTION
This repo does not compile with cmake 3.10 because its "ale" dependency, which is included as a submodule, needs cmake 3.15.

Also, the "conda create" command fails with the "-y" flag. This is confirmed by the doc of this command, where the "-y" flag is not present: 

https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#creating-an-environment-with-commands