### PR TITLE
Add functions for applying transform to SAR and Frame sensor

### DIFF
--- a/include/usgscsm/UsgsAstroFrameSensorModel.h
+++ b/include/usgscsm/UsgsAstroFrameSensorModel.h
@@ -34,8 +34,16 @@ class UsgsAstroFrameSensorModel : public csm::RasterGM,
       double *achievedPrecision = NULL,
       csm::WarningList *warnings = NULL) const;
 
+  static std::string getModelNameFromModelState(const std::string& model_state);
+
   std::string constructStateFromIsd(const std::string &jsonIsd,
                                     csm::WarningList *warnings);
+  
+  // Apply a rotation and translation to a state string. The effect is
+  // to transform the position and orientation of the camera in ECEF
+  // coordinates.
+  static void applyTransformToState(ale::Rotation const& r, ale::Vec3d const& t,
+                                    std::string& stateString);
   void reset();
 
   virtual csm::ImageCoordCovar groundToImage(

--- a/include/usgscsm/UsgsAstroSarSensorModel.h
+++ b/include/usgscsm/UsgsAstroSarSensorModel.h
@@ -5,6 +5,8 @@
 #include <RasterGM.h>
 #include <SettableEllipsoid.h>
 
+#include "ale/Rotation.h"
+
 #include "spdlog/spdlog.h"
 
 class UsgsAstroSarSensorModel : public csm::RasterGM,
@@ -24,8 +26,14 @@ class UsgsAstroSarSensorModel : public csm::RasterGM,
   std::string constructStateFromIsd(const std::string imageSupportData,
                                     csm::WarningList* list);
 
-  std::string getModelNameFromModelState(const std::string& model_state);
+  static std::string getModelNameFromModelState(const std::string& model_state);
 
+  // Apply a rotation and translation to a state string. The effect is
+  // to transform the position and orientation of the camera in ECEF
+  // coordinates.
+  static void applyTransformToState(ale::Rotation const& r, ale::Vec3d const& t,
+                                    std::string& stateString);
+  
   virtual csm::ImageCoord groundToImage(
       const csm::EcefCoord& groundPt, double desiredPrecision = 0.001,
       double* achievedPrecision = NULL,

--- a/src/UsgsAstroLsSensorModel.cpp
+++ b/src/UsgsAstroLsSensorModel.cpp
@@ -468,6 +468,11 @@ void UsgsAstroLsSensorModel::applyTransformToState(ale::Rotation const& r, ale::
   applyRotationTranslationToXyzVec(r, zero_t, velocities);
   j["m_velocities"] = velocities;
 
+  // Apply the transform to the reference point
+  std::vector<double> refPt = j["m_referencePointXyz"];
+  applyRotationTranslationToXyzVec(r, t, refPt);
+  j["m_referencePointXyz"] = refPt;
+
   // We do not change the Sun position or velocity. The idea is that
   // the Sun is so far, that minor camera adjustments won't affect
   // where the Sun is.
@@ -475,6 +480,7 @@ void UsgsAstroLsSensorModel::applyTransformToState(ale::Rotation const& r, ale::
   // Update the state string
   stateString = getModelNameFromModelState(stateString) + "\n" + j.dump(2);
 }
+
 //***************************************************************************
 // UsgsAstroLineScannerSensorModel::reset
 //***************************************************************************

--- a/src/Utilities.cpp
+++ b/src/Utilities.cpp
@@ -55,7 +55,7 @@ void calculateRotationMatrixFromQuaternions(double q[4],
   rotationMatrix[8] = -q[0] * q[0] - q[1] * q[1] + q[2] * q[2] + q[3] * q[3];
 }
 
-// Compue the distorted focal plane coordinate for a given image pixel
+// Compute the distorted focal plane coordinate for a given image pixel
 // in - line
 // in - sample
 // in - sampleOrigin - the origin of the ccd coordinate system relative to the
@@ -88,7 +88,7 @@ void computeDistortedFocalPlaneCoordinates(
   distortedY = p21 * t1 + p22 * t2;
 }
 
-// Compue the image pixel for a distorted focal plane coordinate
+// Compute the image pixel for a distorted focal plane coordinate
 // in - line
 // in - sample
 // in - sampleOrigin - the origin of the ccd coordinate system relative to the

--- a/tests/FrameCameraTests.cpp
+++ b/tests/FrameCameraTests.cpp
@@ -19,6 +19,19 @@ TEST_F(FrameSensorModel, State) {
   EXPECT_EQ(sensorModel->getModelState(), modelState);
 }
 
+// Apply the identity transform to a state
+TEST_F(FrameSensorModel, ApplyTransformToState) {
+  std::string modelState = sensorModel->getModelState();
+
+  ale::Rotation r; // identity rotation
+  ale::Vec3d t;    // zero translation
+
+  std::string modelState_out = modelState;
+  UsgsAstroFrameSensorModel::applyTransformToState(r, t, modelState_out);
+
+  EXPECT_EQ(modelState, modelState_out);
+}
+
 // centered and slightly off-center:
 TEST_F(FrameSensorModel, Center) {
   csm::ImageCoord imagePt(7.5, 7.5);

--- a/tests/SarTests.cpp
+++ b/tests/SarTests.cpp
@@ -78,6 +78,29 @@ TEST_F(SarSensorModel, State) {
   EXPECT_TRUE(differences.empty());
 }
 
+// Apply the identity transform to a state
+TEST_F(SarSensorModel, ApplyTransformToState) {
+  std::string modelState = sensorModel->getModelState();
+
+  ale::Rotation r; // identity rotation
+  ale::Vec3d t;    // zero translation
+
+  // The input state has some "-0" values which get transformed by
+  // applying the identity transform into "0", which results in the
+  // state string changing. Hence, for this test, compare the results
+  // of applying the identity transform once vs twice, which are the
+  // same.
+
+  // First application
+  UsgsAstroSarSensorModel::applyTransformToState(r, t, modelState);
+
+  // Second application
+  std::string modelState2 = modelState;
+  UsgsAstroSarSensorModel::applyTransformToState(r, t, modelState2);
+
+  EXPECT_EQ(modelState, modelState2);
+}
+
 TEST_F(SarSensorModel, Center) {
   csm::ImageCoord imagePt(500.0, 500.0);
   csm::EcefCoord groundPt = sensorModel->imageToGround(imagePt, 0.0);


### PR DESCRIPTION
I added functions to apply a transform to model state for SAR and Frame sensors (such logic for Linescan sensors was added a while ago). I put unit tests too. 

There are some other very small fixes, including to dump in some more places the model state on multiple lines. 

I made the function getModelNameFromModelState() in the Sar class static as in the rest of the the classes, which required removing some debug lines, which is not likely to affect anything. 

I don't need these functions for ASP, as for now I use a clone of these, but when a new USGSCSM version is pushed to conda, I will use the functions from here instead of the ones in ASP.

These changes were tested very carefully with real data, though the unit test provided here is a trivial one to just go through the motions.