### PR TITLE
Fix for the linescan sensor, the step size can be too big when iterating

### DIFF
--- a/include/usgscsm/UsgsAstroLsSensorModel.h
+++ b/include/usgscsm/UsgsAstroLsSensorModel.h
@@ -125,6 +125,7 @@ class UsgsAstroLsSensorModel : public csm::RasterGM,
   double m_halfTime;
   std::vector<double> m_covariance;
   int m_imageFlipFlag;
+  double m_stepSizeFactor;
 
   std::vector<double> m_sunPosition;
   std::vector<double> m_sunVelocity;

--- a/include/usgscsm/UsgsAstroLsSensorModel.h
+++ b/include/usgscsm/UsgsAstroLsSensorModel.h
@@ -125,7 +125,6 @@ class UsgsAstroLsSensorModel : public csm::RasterGM,
   double m_halfTime;
   std::vector<double> m_covariance;
   int m_imageFlipFlag;
-  double m_stepSizeFactor;
 
   std::vector<double> m_sunPosition;
   std::vector<double> m_sunVelocity;
@@ -977,7 +976,14 @@ class UsgsAstroLsSensorModel : public csm::RasterGM,
 
   // Compute the determinant of a 3x3 matrix
   double determinant3x3(double mat[9]) const;
-
+  
+  // A function whose value will be 0 when the line a given ground
+  // point projects into is found. The obtained line will be
+  // approxPt.line + t.
+  double calcDetectorLineErr(double t, csm::ImageCoord const& approxPt,
+                             const csm::EcefCoord& groundPt,
+                             const std::vector<double>& adj) const;
+  
   csm::NoCorrelationModel _no_corr_model;  // A way to report no correlation
                                            // between images is supported
   std::vector<double>

--- a/src/UsgsAstroLsSensorModel.cpp
+++ b/src/UsgsAstroLsSensorModel.cpp
@@ -666,8 +666,9 @@ void UsgsAstroLsSensorModel::updateState() {
   csm::EcefCoord xyz = imageToGround(ip, refHeight);
 
   // Normally this succeeds on the first attempt, and if not, then on
-  // the second.
-  for (int attempt = 1; attempt <= 10; attempt++) {
+  // the second. For some sensors the desired precision is never
+  // achieved, so don't try this too hard.
+  for (int attempt = 1; attempt <= 2; attempt++) {
 
     // First try with existing m_iTransL, and return achievedPrecision1
     double achievedPrecision1 = 1.0;


### PR DESCRIPTION
This is a fix for the situation when the linescan sensor groundToImage() function fails to converge to desired precision. The problem is that sometimes the step size being used is too big, and it overshoots. The solution is to make the step size smaller when this scenario is detected.

This situation is supposed to happen only for some peculiar sensors. I ran into it with LRO NAC towards the South Pole, as described here: https://github.com/USGS-Astrogeology/usgscsm/issues/357

In situations where things were fine even before, I verified that no changes will happen.

It is not clear how much smaller to try to make the step. Here I chose to make it half the original size when the original one is too big. Presumably, the closer one is to the "optimal" size, the faster the algorithm will converge without overshooting. Yet, it would a fragile thing to do to aim to find the optimal step size, since that is done for just the center pixel when the model is set up. There's always a chance for some other pixel in the sensor this "optimal" step size may be too big.

This fix was validated for 74 LRO NAC images, out of which 19 were failing to converge. Now all converge with pixel differences of under 0.44 pixels when comparing projecting pixels to the ground with the ISIS camera and projecting back with the CSM camera, and vice versa. 
