### PR TITLE
Bugfix in imageToRemoteImagingLocus

### DIFF
--- a/src/UsgsAstroSarSensorModel.cpp
+++ b/src/UsgsAstroSarSensorModel.cpp
@@ -673,10 +673,9 @@ csm::EcefLocus UsgsAstroSarSensorModel::imageToProximateImagingLocus(
 csm::EcefLocus UsgsAstroSarSensorModel::imageToRemoteImagingLocus(
     const csm::ImageCoord& imagePt, double desiredPrecision,
     double* achievedPrecision, csm::WarningList* warnings) const {
-  // Compute the slant range
-  double time =
-      m_startingEphemerisTime + (imagePt.line - 0.5) * m_exposureDuration;
-  csm::EcefVector spacecraftPosition = getSpacecraftPosition(time);
+
+  // Find the sensor coordinates
+  csm::EcefCoord sensorPt = getSensorPosition(imagePt);
 
   // Compute the intersection of the ray traced through the
   // current pixel with the datum.  
@@ -686,8 +685,10 @@ csm::EcefLocus UsgsAstroSarSensorModel::imageToRemoteImagingLocus(
 
   // Normalized direction from camera to ground
   csm::EcefVector dir
-    = normalized(csm::EcefVector(groundPt.x, groundPt.y, groundPt.z) - spacecraftPosition);
-  
+    = normalized(csm::EcefVector(groundPt.x - sensorPt.x,
+                                 groundPt.y - sensorPt.y,
+                                 groundPt.z - sensorPt.z));
+                 
   return csm::EcefLocus(groundPt.x, groundPt.y, groundPt.z,
                         dir.x, dir.y, dir.z);
 }


### PR DESCRIPTION
This is a fix for the fact that imageToRemoteImagingLocus() was giving an incorrect answer (https://github.com/USGS-Astrogeology/usgscsm/issues/350). 

The problem seems to be that this function goes through some of the same motions as imageToGround() (with different notation), but returns the cross-track vector instead of the vector pointing to the ground.

I could have just pasted the same logic as in imageToGround(), or carefully adjusted the existing  imageToRemoteImagingLocus() code along the same lines, but that would have been just code repetition. So, the change I made is to call the correct function imageToGround() and then finish the rest of the calcuation. I used a height of 0 when calling this, since we don't care to hit a specific height above datum, we just want the direction of the ray towards the ground and a point on it. 

While in theory the imageToGround() function that is now invoked is iterative, it finds the solution in the first iteration, since given how the nadir, across track and along track vectors are defined, if one does carefully the math using those formulas it turns out the exact solution is obtained at once. Running the code verifies that. 

Now imageToGround() is consistent with imageToRemoteImagingLocus() and consistent with the ISIS implementation of imageToGround() and groundToImage(). There's still a small discrepancy somewhere (https://github.com/USGS-Astrogeology/usgscsm/issues/349) but now things are at least in the ballpark. 