### PR TITLE
Brent root fix

### DIFF
--- a/src/Utilities.cpp
+++ b/src/Utilities.cpp
@@ -296,7 +296,7 @@ double brentRoot(double lowerBound, double upperBound,
     previousPoint = currentPoint;
     previousFunc = currentFunc;
     nextFunc = func(nextPoint);
-    if (counterFunc * nextFunc < 0) {
+    if (counterFunc * nextFunc <= 0) {
       currentPoint = nextPoint;
       currentFunc = nextFunc;
     } else {

--- a/src/Utilities.cpp
+++ b/src/Utilities.cpp
@@ -296,7 +296,13 @@ double brentRoot(double lowerBound, double upperBound,
     previousPoint = currentPoint;
     previousFunc = currentFunc;
     nextFunc = func(nextPoint);
-    if (counterFunc * nextFunc <= 0) {
+
+    // This is a bugfix. Without it, the code gets lost and can't find the solution.
+    // See also the implementation at https://en.wikipedia.org/wiki/Brent%27s_method
+    if (nextFunc == 0)
+      return nextPoint;
+
+    if (counterFunc * nextFunc < 0) {
       currentPoint = nextPoint;
       currentFunc = nextFunc;
     } else {

--- a/tests/SarTests.cpp
+++ b/tests/SarTests.cpp
@@ -84,10 +84,10 @@ TEST_F(SarSensorModel, computeGroundPartials) {
   ASSERT_EQ(partials.size(), 6);
   EXPECT_NEAR(partials[0], 6.5128150576280552e-09, 1e-8);
   EXPECT_NEAR(partials[1], -5.1810407815840636e-15, 1e-8);
-  EXPECT_NEAR(partials[2], -0.13309947654685725, 1e-8);
+  EXPECT_NEAR(partials[2], -0.13333333443071135, 1e-8);
   EXPECT_NEAR(partials[3], -33.057625791698072, 1e-8);
   EXPECT_NEAR(partials[4], 6.1985123841926308e-05, 1e-8);
-  EXPECT_NEAR(partials[5], 0.007743051337209989, 1e-8);
+  EXPECT_NEAR(partials[5], 0.0077565105243007169, 1e-8);
 }
 
 TEST_F(SarSensorModel, imageToProximateImagingLocus) {


### PR DESCRIPTION
I found a bug in the brentRoot() code for finding a root of a function. This was preventing the SAR groundToImage() function from converging on occasion.

This root-finding algorithm starts with function values of opposite signs at the ends of an interval, then narrows down the interval while still keeping function values of opposite sign, till the interval is below tolerance length, then it declares to have found the solution.  

If however the algorithm runs into a position where the function value is precisely 0, it can't believe its luck, and keeps on going through the motions, while returning a poor value for the root.

Per Wikipedia, https://en.wikipedia.org/wiki/Brent%27s_method, there must be an additional check for this, which is missing. I put it in. 

To reproduce that the current bugfix is an improvement, edit the brentRoot() function body, with and without this fix, and after the line  nextFunc = func(nextPoint), print the value of nextFunc. 

After this, run:

  ctest -R SarSensorModel.computeGroundPartials

It will show that once the algorithm hits on the root, but keeps on going, the function value actually moves away from the value of 0, which is not a good thing. 
