### PR TITLE
Fix for 0.5 pixel shift in the SAR model

### DIFF
--- a/src/UsgsAstroSarSensorModel.cpp
+++ b/src/UsgsAstroSarSensorModel.cpp
@@ -374,7 +374,7 @@ csm::ImageCoord UsgsAstroSarSensorModel::groundToImage(
         groundPt, time, slantRangeValue, groundTolerance);
 
     double line = (time - m_startingEphemerisTime) / m_exposureDuration + 0.5;
-    double sample = groundRange / m_scaledPixelWidth;
+    double sample = groundRange / m_scaledPixelWidth + 0.5;
     return csm::ImageCoord(line, sample);
   } catch (std::exception& error) {
     std::string message = "Could not calculate groundToImage, with error [";
@@ -504,7 +504,7 @@ csm::EcefCoord UsgsAstroSarSensorModel::imageToGround(
               imagePt.line, height, desiredPrecision);
   double time =
       m_startingEphemerisTime + (imagePt.line - 0.5) * m_exposureDuration;
-  double groundRange = imagePt.samp * m_scaledPixelWidth;
+  double groundRange = (imagePt.samp - 0.5) * m_scaledPixelWidth;
   std::vector<double> coeffs = getRangeCoefficients(time);
   double slantRange = groundRangeToSlantRange(groundRange, coeffs);
 
@@ -640,7 +640,7 @@ csm::EcefLocus UsgsAstroSarSensorModel::imageToProximateImagingLocus(
   // Compute the slant range
   double time =
       m_startingEphemerisTime + (imagePt.line - 0.5) * m_exposureDuration;
-  double groundRange = imagePt.samp * m_scaledPixelWidth;
+  double groundRange = (imagePt.samp - 0.5) * m_scaledPixelWidth;
   std::vector<double> coeffs = getRangeCoefficients(time);
   double slantRange = groundRangeToSlantRange(groundRange, coeffs);
 

--- a/tests/SarTests.cpp
+++ b/tests/SarTests.cpp
@@ -49,17 +49,7 @@ TEST_F(SarSensorModel, Center) {
 }
 
 TEST_F(SarSensorModel, GroundToImage) {
-  csm::ImageCoord I;
-  I.samp = 500.0; 
-  I.line = 500.0;
-  double height = 0;
-  double desiredPrecision = 1e-8;
-  csm::EcefCoord G = sensorModel->imageToGround(I, height, desiredPrecision);
-  std::cout.precision(17);
-  std::cout << "G is " << G.x << ' ' << G.y << ' ' << G.z << std::endl;
   csm::EcefCoord groundPt(1737387.8671710272, -5300.6282306119301, -3749.9796358514604);
-  std::cout << "G2 is " << groundPt.x << ' ' << groundPt.y << ' ' << groundPt.z << std::endl;
-  
   csm::ImageCoord imagePt = sensorModel->groundToImage(groundPt, 0.001);
   EXPECT_NEAR(imagePt.line, 500.0, 1e-3);
   EXPECT_NEAR(imagePt.samp, 500.0, 1e-3);

--- a/tests/SarTests.cpp
+++ b/tests/SarTests.cpp
@@ -49,11 +49,20 @@ TEST_F(SarSensorModel, Center) {
 }
 
 TEST_F(SarSensorModel, GroundToImage) {
-  csm::EcefCoord groundPt(1737387.8590770673, -5303.280537826621,
-                          -3749.9796183814506);
+  csm::ImageCoord I;
+  I.samp = 500.0; 
+  I.line = 500.0;
+  double height = 0;
+  double desiredPrecision = 1e-8;
+  csm::EcefCoord G = sensorModel->imageToGround(I, height, desiredPrecision);
+  std::cout.precision(17);
+  std::cout << "G is " << G.x << ' ' << G.y << ' ' << G.z << std::endl;
+  csm::EcefCoord groundPt(1737387.8671710272, -5300.6282306119301, -3749.9796358514604);
+  std::cout << "G2 is " << groundPt.x << ' ' << groundPt.y << ' ' << groundPt.z << std::endl;
+  
   csm::ImageCoord imagePt = sensorModel->groundToImage(groundPt, 0.001);
   EXPECT_NEAR(imagePt.line, 500.0, 1e-3);
-  EXPECT_NEAR(imagePt.samp, 500.5, 1e-3);
+  EXPECT_NEAR(imagePt.samp, 500.0, 1e-3);
 }
 
 TEST_F(SarSensorModel, spacecraftPosition) {

--- a/tests/SarTests.cpp
+++ b/tests/SarTests.cpp
@@ -43,8 +43,8 @@ TEST_F(SarSensorModel, State) {
 TEST_F(SarSensorModel, Center) {
   csm::ImageCoord imagePt(500.0, 500.0);
   csm::EcefCoord groundPt = sensorModel->imageToGround(imagePt, 0.0);
-  EXPECT_NEAR(groundPt.x, 1737387.8590770673, 1e-3);
-  EXPECT_NEAR(groundPt.y, -5303.280537826621, 1e-3);
+  EXPECT_NEAR(groundPt.x, 1737387.8671710272, 1e-3);
+  EXPECT_NEAR(groundPt.y, -5300.6282306119301, 1e-3);
   EXPECT_NEAR(groundPt.z, -3749.9796183814506, 1e-3);
 }
 
@@ -53,7 +53,7 @@ TEST_F(SarSensorModel, GroundToImage) {
                           -3749.9796183814506);
   csm::ImageCoord imagePt = sensorModel->groundToImage(groundPt, 0.001);
   EXPECT_NEAR(imagePt.line, 500.0, 1e-3);
-  EXPECT_NEAR(imagePt.samp, 500.0, 1e-3);
+  EXPECT_NEAR(imagePt.samp, 500.5, 1e-3);
 }
 
 TEST_F(SarSensorModel, spacecraftPosition) {
@@ -100,7 +100,7 @@ TEST_F(SarSensorModel, imageToProximateImagingLocus) {
       0.001,
       &precision,
       &warnings);
-  EXPECT_NEAR(locus.point.x, 1737388.1260092105, 1e-2);
+  EXPECT_NEAR(locus.point.x, 1737388.1411342232, 1e-2);
   EXPECT_NEAR(locus.point.y, -5403.0102509726485, 1e-2);
   EXPECT_NEAR(locus.point.z, -3749.9801945280433, 1e-2);
   EXPECT_NEAR(locus.direction.x, 0.002701478402694769, 1e-5);


### PR DESCRIPTION
This is a fix for https://github.com/USGS-Astrogeology/usgscsm/issues/349. The ISIS and CSM SAR models were disagreeing by 0.5 pixels.

To verify that the problem still exists, I upgraded to ISIS 6.0.0, set ISISROOT and PATH to reflect this version, then ran the script vis.py from knoten. Here were the stats printed before:

  isis2csm_data
          diff line  diff sample
  count  100.000000   100.000000
  mean     0.000653     0.500945
  std      0.000364     0.000868
  min      0.000088     0.499861
  25%      0.000334     0.500069
  50%      0.000661     0.500880
  75%      0.000985     0.501837
  max      0.001184     0.502175
  
  csm2isis_data
          diff line  diff sample
  count  100.000000   100.000000
  mean    -0.000587    -0.499855
  std      0.000331     0.003402
  min     -0.000953    -0.502177
  25%     -0.000923    -0.501837
  50%     -0.000649    -0.500627
  75%     -0.000299    -0.500036
  max     -0.000013    -0.490000
  
  isiscsm_latlondata
             diff lon      diff lat
  count  1.000000e+02  1.000000e+02
  mean  -1.241588e-04 -3.008199e-08
  std    2.149002e-07  8.218436e-08
  min   -1.244671e-04 -1.726170e-07
  25%   -1.243787e-04 -1.023781e-07
  50%   -1.241339e-04 -1.544742e-08
  75%   -1.239420e-04  5.489514e-08
  max   -1.238807e-04  6.124550e-08
  
  isiscsm_bfdata
              diffx       diffy       diffz
  count  100.000000  100.000000  100.000000
  mean    -0.000484   -1.883225    0.000912
  std      3.156248    0.003302    0.002492
  min     -3.141573   -1.888560   -0.001857
  25%     -3.140706   -1.886571   -0.001664
  50%     -0.000899   -1.882793    0.000468
  75%      3.139946   -1.879961    0.003104
  max      3.141077   -1.878461    0.005233

Note the last column in each of the first two blocks. 

Here are the stats after the fix:

isis2csm_data
          diff line  diff sample
  count  100.000000   100.000000
  mean     0.000653     0.000945
  std      0.000364     0.000868
  min      0.000088    -0.000139
  25%      0.000334     0.000069
  50%      0.000661     0.000880
  75%      0.000985     0.001837
  max      0.001184     0.002175
  
  csm2isis_data
          diff line  diff sample
  count  100.000000   100.000000
  mean    -0.000587    -0.000946
  std      0.000331     0.000868
  min     -0.000953    -0.002177
  25%     -0.000923    -0.001838
  50%     -0.000649    -0.000881
  75%     -0.000299    -0.000069
  max     -0.000013     0.000137
  
  isiscsm_latlondata
             diff lon      diff lat
  count  1.000000e+02  1.000000e+02
  mean  -2.345560e-07  1.449755e-07
  std    2.151477e-07  8.268787e-08
  min   -5.392443e-07  2.101926e-09
  25%   -4.555451e-07  7.220405e-08
  50%   -2.182342e-07  1.596107e-07
  75%   -1.745728e-08  2.304278e-07
  max    3.442275e-08  2.366007e-07
  
  isiscsm_bfdata
              diffx       diffy       diffz
  count  100.000000  100.000000  100.000000
  mean    -2.033798   -0.003477   -0.004395
  std      0.805706    0.003278    0.002507
  min     -2.873404   -0.008117   -0.007173
  25%     -2.759154   -0.006870   -0.006986
  50%     -2.156677   -0.003240   -0.004839
  75%     -1.589657   -0.000134   -0.002189
  max     -0.123064    0.000523   -0.000064
