### PR TITLE
Add the tool usgscsm_cam_test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,6 @@ include/csm/*
 # iPython checkpoint items
 .ipynb_checkpoints
 
-# Ignore any executables
-bin/*
-
 # Ignore any Mac stuff
 .DS_Store
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,4 +103,10 @@ if(USGSCSM_BUILD_TESTS)
   include(CTest)
   enable_testing()
   add_subdirectory(tests)
+
+  # Test the test_usgscsm_cam_test program
+  add_test(NAME test_usgscsm_cam_test_linescan
+      COMMAND usgscsm_cam_test data/orbitalLineScan.json
+      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests)
+      
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,10 +80,13 @@ target_link_libraries(usgscsm
                       ${ALE_TARGET}
                       nlohmann_json::nlohmann_json)
 
+add_executable(usgscsm_cam_test bin/usgscsm_cam_test.cc)
+target_link_libraries(usgscsm_cam_test
+    usgscsm)
 
 install(TARGETS usgscsm LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(DIRECTORY ${USGSCSM_INCLUDE_DIRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-
+install(TARGETS usgscsm_cam_test RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Optional build tests
 option (USGSCSM_BUILD_TESTS "Build tests" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,9 +104,4 @@ if(USGSCSM_BUILD_TESTS)
   enable_testing()
   add_subdirectory(tests)
 
-  # Test the test_usgscsm_cam_test program
-  add_test(NAME test_usgscsm_cam_test_linescan
-      COMMAND usgscsm_cam_test data/orbitalLineScan.json
-      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests)
-      
 endif()

--- a/bin/usgscsm_cam_test.cc
+++ b/bin/usgscsm_cam_test.cc
@@ -30,10 +30,13 @@ int main(int argc, char **argv) {
   // Load the isd
   std::string model_file = argv[1];
   csm::Isd isd(model_file);
+  std::cout << "Loading model: " << model_file << std::endl;
   
   // Check if loading the model worked
   bool success = false;
 
+  std::shared_ptr<csm::RasterGM> model;
+  
   // Try all detected plugins and models for each plugin
   csm::PluginList plugins = csm::Plugin::getList();
   for (auto iter = plugins.begin(); iter != plugins.end(); iter++) {
@@ -48,14 +51,13 @@ int main(int argc, char **argv) {
 
       std::string model_name = (*iter)->getModelName(i);
 
-      std::shared_ptr<csm::RasterGM> model;
       csm::WarningList* warnings = NULL;
 
       if (csm_plugin->canModelBeConstructedFromISD(isd, model_name)) {
 
         csm::Model *csm = csm_plugin->constructModelFromISD(isd, model_name, warnings);
         csm::RasterGM *modelPtr = dynamic_cast<csm::RasterGM*>(csm);
-        
+
         if (modelPtr == NULL) {
           std::cerr << "Could not load correctly a CSM model of type: "
                     << model_name << "\n";
@@ -75,6 +77,10 @@ int main(int argc, char **argv) {
     std::cerr << "Failed to load a CSM model from: " << model_file << ".\n";
     return 1;
   }
+
+  csm::ImageVector image_size = model->getImageSize();
+  std::cout << "Camera image rows and columns: "
+            << image_size.samp << ' ' << image_size.line << "\n";
 
   return 0;
 }

--- a/bin/usgscsm_cam_test.cc
+++ b/bin/usgscsm_cam_test.cc
@@ -1,0 +1,16 @@
+// A tool to perform some basic tests and operations on a CSM camera model.
+// Functionality:
+// 
+// - Test projecting rays from the camera to ground and vice-versa.
+
+#include <usgscsm/UsgsAstroPlugin.h>
+#include <usgscsm/UsgsAstroLsSensorModel.h>
+#include <usgscsm/UsgsAstroFrameSensorModel.h>
+#include <usgscsm/UsgsAstroSarSensorModel.h>
+
+#include <iostream>
+int main(int argc, char **argv) {
+  std::cout << "--test is xxx"  << std::endl;
+  return 0;
+}
+

--- a/bin/usgscsm_cam_test.cc
+++ b/bin/usgscsm_cam_test.cc
@@ -1,16 +1,56 @@
 // A tool to perform some basic tests and operations on a CSM camera model.
+// 
 // Functionality:
+//
+// - Load a CSM model in ISD format.
+//
+// Future functionality:
 // 
 // - Test projecting rays from the camera to ground and vice-versa.
+// - Load a CSM model state (stored in a .json file, just like
+//   an ISD model).
+// - Ability to export a CSM model in ISD format to a CSM model state file. 
 
 #include <usgscsm/UsgsAstroPlugin.h>
-#include <usgscsm/UsgsAstroLsSensorModel.h>
-#include <usgscsm/UsgsAstroFrameSensorModel.h>
-#include <usgscsm/UsgsAstroSarSensorModel.h>
+#include <csm/RasterGM.h>
 
 #include <iostream>
 int main(int argc, char **argv) {
-  std::cout << "--test is xxx"  << std::endl;
+
+  if (argc != 2) {
+    std::cerr << "Usage: " << argv[0] << " <model file>" << std::endl;
+    return 1;
+  }
+  
+  std::string model_file = argv[1];
+  csm::Isd isd(model_file);
+
+  std::vector<std::string> model_types = {"USGS_ASTRO_FRAME_SENSOR_MODEL",
+                                          "USGS_ASTRO_LINE_SCANNER_SENSOR_MODEL",
+                                          "USGS_ASTRO_SAR_SENSOR_MODEL"};
+
+  // Try to load the model
+  UsgsAstroPlugin plugin;
+  std::shared_ptr<csm::RasterGM> model;
+  csm::WarningList* warnings = NULL;
+  for (size_t it = 0; it < model_types.size(); it++) {
+    if (plugin.canModelBeConstructedFromISD(isd, model_types[it])) {
+
+      csm::Model *csm = plugin.constructModelFromISD(isd, model_types[it], warnings);
+      csm::RasterGM *modelPtr = dynamic_cast<csm::RasterGM*>(csm);
+
+      if (modelPtr == NULL) {
+        std::cerr << "Could not load correctly a CSM model of type: "
+                  << model_types[it] << std::endl;
+      } else {
+        // Assign it to a smart pointer which will handle its deallocation
+        model = std::shared_ptr<csm::RasterGM>(modelPtr);
+        std::cout << "Loaded CSM model of type " << model_types[it]
+                  << " from " << model_file << ".\n";
+      }
+    }
+  }
+
   return 0;
 }
 

--- a/bin/usgscsm_cam_test.cc
+++ b/bin/usgscsm_cam_test.cc
@@ -30,6 +30,7 @@ int main(int argc, char **argv) {
                                           "USGS_ASTRO_SAR_SENSOR_MODEL"};
 
   // Try to load the model
+  bool success = false;
   UsgsAstroPlugin plugin;
   std::shared_ptr<csm::RasterGM> model;
   csm::WarningList* warnings = NULL;
@@ -42,13 +43,20 @@ int main(int argc, char **argv) {
       if (modelPtr == NULL) {
         std::cerr << "Could not load correctly a CSM model of type: "
                   << model_types[it] << std::endl;
+        return 1;
       } else {
         // Assign it to a smart pointer which will handle its deallocation
         model = std::shared_ptr<csm::RasterGM>(modelPtr);
+        success = true;
         std::cout << "Loaded CSM model of type " << model_types[it]
                   << " from " << model_file << ".\n";
       }
     }
+  }
+
+  if (!success) {
+    std::cerr << "Failed to load a CSM model from: " << model_file << ".\n";
+    return 1;
   }
 
   return 0;

--- a/bin/usgscsm_cam_test.cc
+++ b/bin/usgscsm_cam_test.cc
@@ -13,6 +13,7 @@
 
 #include <usgscsm/UsgsAstroPlugin.h>
 #include <csm/RasterGM.h>
+#include <UsgsAstroLsSensorModel.h>
 
 #include <iostream>
 int main(int argc, char **argv) {
@@ -21,39 +22,55 @@ int main(int argc, char **argv) {
     std::cerr << "Usage: " << argv[0] << " <model file>" << std::endl;
     return 1;
   }
-  
+
+  // This is needed to trigger loading libusgscsm.so. Otherwise 0
+  // plugins are detected.
+  UsgsAstroLsSensorModel lsModel;
+
+  // Load the isd
   std::string model_file = argv[1];
   csm::Isd isd(model_file);
-
-  std::vector<std::string> model_types = {"USGS_ASTRO_FRAME_SENSOR_MODEL",
-                                          "USGS_ASTRO_LINE_SCANNER_SENSOR_MODEL",
-                                          "USGS_ASTRO_SAR_SENSOR_MODEL"};
-
-  // Try to load the model
+  
+  // Check if loading the model worked
   bool success = false;
-  UsgsAstroPlugin plugin;
-  std::shared_ptr<csm::RasterGM> model;
-  csm::WarningList* warnings = NULL;
-  for (size_t it = 0; it < model_types.size(); it++) {
-    if (plugin.canModelBeConstructedFromISD(isd, model_types[it])) {
 
-      csm::Model *csm = plugin.constructModelFromISD(isd, model_types[it], warnings);
-      csm::RasterGM *modelPtr = dynamic_cast<csm::RasterGM*>(csm);
+  // Try all detected plugins and models for each plugin
+  csm::PluginList plugins = csm::Plugin::getList();
+  for (auto iter = plugins.begin(); iter != plugins.end(); iter++) {
+    
+    const csm::Plugin* csm_plugin = (*iter);
 
-      if (modelPtr == NULL) {
-        std::cerr << "Could not load correctly a CSM model of type: "
-                  << model_types[it] << std::endl;
-        return 1;
-      } else {
-        // Assign it to a smart pointer which will handle its deallocation
-        model = std::shared_ptr<csm::RasterGM>(modelPtr);
-        success = true;
-        std::cout << "Loaded CSM model of type " << model_types[it]
-                  << " from " << model_file << ".\n";
+    std::cout << "Detected CSM plugin: " << csm_plugin->getPluginName()  << "\n";
+    // For each plugin, loop through the available models.
+    size_t num_models = csm_plugin->getNumModels();
+    std::cout << "Number of models for this plugin: " << num_models << "\n";
+    for (size_t i = 0; i < num_models; i++) {
+
+      std::string model_name = (*iter)->getModelName(i);
+
+      std::shared_ptr<csm::RasterGM> model;
+      csm::WarningList* warnings = NULL;
+
+      if (csm_plugin->canModelBeConstructedFromISD(isd, model_name)) {
+
+        csm::Model *csm = csm_plugin->constructModelFromISD(isd, model_name, warnings);
+        csm::RasterGM *modelPtr = dynamic_cast<csm::RasterGM*>(csm);
+        
+        if (modelPtr == NULL) {
+          std::cerr << "Could not load correctly a CSM model of type: "
+                    << model_name << "\n";
+          return 1;
+        } else {
+          // Assign it to a smart pointer which will handle its deallocation
+          model = std::shared_ptr<csm::RasterGM>(modelPtr);
+          success = true;
+          std::cout << "Loaded CSM model of type " << model_name
+                    << " from " << model_file << ".\n";
+        }
       }
     }
   }
-
+  
   if (!success) {
     std::cerr << "Failed to load a CSM model from: " << model_file << ".\n";
     return 1;
@@ -61,4 +78,3 @@ int main(int argc, char **argv) {
 
   return 0;
 }
-

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,4 +17,9 @@ else()
     target_link_libraries(runCSMCameraModelTests usgscsm ${GTEST_LIBRARIES} ${GTEST_MAIN_LIBRARIES} pthread)
 endif()
 
+# Test the test_usgscsm_cam_test program
+add_test(NAME test_usgscsm_cam_test_linescan
+    COMMAND usgscsm_cam_test data/orbitalLineScan.json
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests)
+      
 gtest_discover_tests(runCSMCameraModelTests WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests)


### PR DESCRIPTION
This is a tool intended to be shipped with the usgscsm library (it will install itself in 'bin'). The goal is for the user to invoke it for basic sanity checks of CSM models. For now, all it can do is load a CSM model, for example, as:

    bin/usgscsm_cam_test tests/data/orbitalSar.json 

when it will produce output:

    Loaded CSM model of type USGS_ASTRO_SAR_SENSOR_MODEL from ../tests/data/orbitalSar.json.

Future proposed functionality:

 - Test projecting rays from the camera to ground and vice-versa, with given sample rate.
 - Load a CSM model state (stored in a .json file, just like an ISD model).
 - Ability to export a CSM model in ISD format to a CSM model state file. 


