### PR TITLE
SAR model: Fix an infinite loop issue

### DIFF
--- a/src/UsgsAstroSarSensorModel.cpp
+++ b/src/UsgsAstroSarSensorModel.cpp
@@ -524,12 +524,15 @@ csm::EcefCoord UsgsAstroSarSensorModel::imageToGround(
   //   The cross-track unit vector is orthogonal to the position so we ignore it
   double nadirComp = dot(spacecraftPosition, tHat);
 
-  // Iterate to find proper radius value
+  // Iterate to find proper radius value. Limit the number of iterations
+  // because the desired precision may not drop beyond 1e-10 no matter
+  // how many iterations one does. As it was observed, this in fact
+  // converges at the first iteration.
   double pointRadius = m_majorAxis + height;
   double radiusSqr;
   double pointHeight;
   csm::EcefVector groundVec;
-  do {
+  for (int it = 0; it < 10; it++) {
     radiusSqr = pointRadius * pointRadius;
     double alpha =
         (radiusSqr - slantRange * slantRange - positionMag * positionMag) /
@@ -542,7 +545,10 @@ csm::EcefCoord UsgsAstroSarSensorModel::imageToGround(
     pointHeight = computeEllipsoidElevation(
         groundVec.x, groundVec.y, groundVec.z, m_majorAxis, m_minorAxis);
     pointRadius -= (pointHeight - height);
-  } while (fabs(pointHeight - height) > desiredPrecision);
+
+    if (fabs(pointHeight - height) <= desiredPrecision)
+      break;
+  }
 
   if (achievedPrecision) {
     *achievedPrecision = fabs(pointHeight - height);


### PR DESCRIPTION
I found a situation where the imageToGround() function in the SAR model got in an infinite loop because it could not bring the desired precision to under 1e-10 and 1e-11 was asked. The solution is to limit the number of iterations instead of using a "while" loop.

As an aside, normally we'd expect machine precision in such calculation, but given that it has to deal with the body radius in meters, which is 1737400.0, likely some precision loss happens. 

As a second aside, it looks to me that iterations are not even necessary here. This calculation seems to intersect a ray with an ellipsoid, and that one has an exact solution. The loop here hits an error of 1e-10 in the first iteration and then just goes around that not making any further progress. But this would require some more careful math than what I did to prove for sure, as I did not follow precisely the slant range calculation and the logic of decomposing a vector using a basis of what this code calls uHat, vHat, and tHat. 