### PR TITLE
Avoid using pointers where a std::shared_ptr can be used

### DIFF
--- a/src/UsgsAstroFrameSensorModel.cpp
+++ b/src/UsgsAstroFrameSensorModel.cpp
@@ -899,7 +899,7 @@ std::string UsgsAstroFrameSensorModel::constructStateFromIsd(
 
   MESSAGE_LOG("Constructing state from isd");
 
-  csm::WarningList *parsingWarnings = new csm::WarningList;
+  std::shared_ptr<csm::WarningList> parsingWarnings(new csm::WarningList);
 
   state["m_modelName"] = ale::getSensorModelName(parsedIsd);
   state["m_imageIdentifier"] = ale::getImageId(parsedIsd);
@@ -1115,17 +1115,12 @@ std::string UsgsAstroFrameSensorModel::constructStateFromIsd(
       warnings->insert(warnings->end(), parsingWarnings->begin(),
                        parsingWarnings->end());
     }
-    delete parsingWarnings;
-    parsingWarnings = nullptr;
     MESSAGE_LOG("ISD is invalid for creating the sensor model.");
 
     throw csm::Error(csm::Error::SENSOR_MODEL_NOT_CONSTRUCTIBLE,
                      "ISD is invalid for creating the sensor model.",
                      "UsgsAstroFrameSensorModel::constructStateFromIsd");
   }
-
-  delete parsingWarnings;
-  parsingWarnings = nullptr;
 
   return state.dump();
 }

--- a/src/UsgsAstroLsSensorModel.cpp
+++ b/src/UsgsAstroLsSensorModel.cpp
@@ -2265,7 +2265,7 @@ std::string UsgsAstroLsSensorModel::constructStateFromIsd(
   MESSAGE_LOG("Constructing state from Isd")
   // Instantiate UsgsAstroLineScanner sensor model
   json jsonIsd = json::parse(imageSupportData);
-  csm::WarningList* parsingWarnings = new csm::WarningList;
+  std::shared_ptr<csm::WarningList> parsingWarnings(new csm::WarningList);
 
   state["m_modelName"] = ale::getSensorModelName(jsonIsd);
   state["m_imageIdentifier"] = ale::getImageId(jsonIsd);
@@ -2397,10 +2397,10 @@ std::string UsgsAstroLsSensorModel::constructStateFromIsd(
 
   std::vector<std::vector<double>> lineScanRate = ale::getLineScanRate(jsonIsd);
   state["m_intTimeLines"] =
-      getIntegrationStartLines(lineScanRate, parsingWarnings);
+    getIntegrationStartLines(lineScanRate, parsingWarnings.get());
   state["m_intTimeStartTimes"] =
-      getIntegrationStartTimes(lineScanRate, parsingWarnings);
-  state["m_intTimes"] = getIntegrationTimes(lineScanRate, parsingWarnings);
+    getIntegrationStartTimes(lineScanRate, parsingWarnings.get());
+  state["m_intTimes"] = getIntegrationTimes(lineScanRate, parsingWarnings.get());
   MESSAGE_LOG(
       "m_intTimeLines: {} "
       "m_intTimeStartTimes: {} "
@@ -2566,15 +2566,10 @@ std::string UsgsAstroLsSensorModel::constructStateFromIsd(
       warnings->insert(warnings->end(), parsingWarnings->begin(),
                        parsingWarnings->end());
     }
-    delete parsingWarnings;
-    parsingWarnings = nullptr;
     throw csm::Error(csm::Error::SENSOR_MODEL_NOT_CONSTRUCTIBLE,
                      "ISD is invalid for creating the sensor model.",
                      "UsgsAstroFrameSensorModel::constructStateFromIsd");
   }
-
-  delete parsingWarnings;
-  parsingWarnings = nullptr;
 
   // The state data will still be updated when a sensor model is created since
   // some state data is not in the ISD and requires a SM to compute them.

--- a/src/UsgsAstroPlugin.cpp
+++ b/src/UsgsAstroPlugin.cpp
@@ -165,12 +165,10 @@ bool UsgsAstroPlugin::canModelBeConstructedFromISD(
     const csm::Isd &imageSupportData, const std::string &modelName,
     csm::WarningList *warnings) const {
   try {
-    csm::Model *model =
-        constructModelFromISD(imageSupportData, modelName, warnings);
-    if (model) {
-      delete model;
+    std::shared_ptr<csm::Model> model(constructModelFromISD(imageSupportData, modelName, warnings));
+    if (model)
       return true;
-    }
+
   } catch (std::exception &e) {
     if (warnings) {
       std::string msg = "Could not create model [";
@@ -284,10 +282,9 @@ std::string UsgsAstroPlugin::convertISDToModelState(
     const csm::Isd &imageSupportData, const std::string &modelName,
     csm::WarningList *warnings) const {
   MESSAGE_LOG("Running convertISDToModelState");
-  csm::Model *sensor_model =
-      constructModelFromISD(imageSupportData, modelName, warnings);
+  std::shared_ptr<csm::Model> sensor_model
+    (constructModelFromISD(imageSupportData, modelName, warnings));
   std::string stateString = sensor_model->getModelState();
-  delete sensor_model;
   return stateString;
 }
 

--- a/src/UsgsAstroPushFrameSensorModel.cpp
+++ b/src/UsgsAstroPushFrameSensorModel.cpp
@@ -2061,7 +2061,7 @@ std::string UsgsAstroPushFrameSensorModel::constructStateFromIsd(
   MESSAGE_LOG("Constructing state from Isd")
   // Instantiate UsgsAstroLineScanner sensor model
   json jsonIsd = json::parse(imageSupportData);
-  csm::WarningList* parsingWarnings = new csm::WarningList;
+  std::shared_ptr<csm::WarningList> parsingWarnings(new csm::WarningList);
 
   state["m_modelName"] = ale::getSensorModelName(jsonIsd);
   state["m_imageIdentifier"] = ale::getImageId(jsonIsd);
@@ -2380,15 +2380,10 @@ std::string UsgsAstroPushFrameSensorModel::constructStateFromIsd(
       warnings->insert(warnings->end(), parsingWarnings->begin(),
                        parsingWarnings->end());
     }
-    delete parsingWarnings;
-    parsingWarnings = nullptr;
     throw csm::Error(csm::Error::SENSOR_MODEL_NOT_CONSTRUCTIBLE,
                      "ISD is invalid for creating the sensor model.",
                      "UsgsAstroFrameSensorModel::constructStateFromIsd");
   }
-
-  delete parsingWarnings;
-  parsingWarnings = nullptr;
 
   // The state data will still be updated when a sensor model is created since
   // some state data is not in the ISD and requires a SM to compute them.

--- a/src/UsgsAstroSarSensorModel.cpp
+++ b/src/UsgsAstroSarSensorModel.cpp
@@ -42,28 +42,28 @@ string UsgsAstroSarSensorModel::constructStateFromIsd(
   json isd = json::parse(imageSupportData);
   json state = {};
 
-  csm::WarningList* parsingWarnings = new csm::WarningList;
+  std::shared_ptr<csm::WarningList> parsingWarnings(new csm::WarningList);
 
-  state["m_modelName"] = getSensorModelName(isd, parsingWarnings);
-  state["m_imageIdentifier"] = getImageId(isd, parsingWarnings);
-  state["m_sensorName"] = getSensorName(isd, parsingWarnings);
-  state["m_platformName"] = getPlatformName(isd, parsingWarnings);
+  state["m_modelName"] = getSensorModelName(isd, parsingWarnings.get());
+  state["m_imageIdentifier"] = getImageId(isd, parsingWarnings.get());
+  state["m_sensorName"] = getSensorName(isd, parsingWarnings.get());
+  state["m_platformName"] = getPlatformName(isd, parsingWarnings.get());
 
-  state["m_nLines"] = getTotalLines(isd, parsingWarnings);
-  state["m_nSamples"] = getTotalSamples(isd, parsingWarnings);
+  state["m_nLines"] = getTotalLines(isd, parsingWarnings.get());
+  state["m_nSamples"] = getTotalSamples(isd, parsingWarnings.get());
 
   // Zero computed state values
   state["m_referencePointXyz"] = vector<double>(3, 0.0);
 
   // sun_position and velocity are required for getIlluminationDirection
-  state["m_sunPosition"] = getSunPositions(isd, parsingWarnings);
-  state["m_sunVelocity"] = getSunVelocities(isd, parsingWarnings);
+  state["m_sunPosition"] = getSunPositions(isd, parsingWarnings.get());
+  state["m_sunVelocity"] = getSunVelocities(isd, parsingWarnings.get());
 
-  state["m_centerEphemerisTime"] = getCenterTime(isd, parsingWarnings);
-  state["m_startingEphemerisTime"] = getStartingTime(isd, parsingWarnings);
-  state["m_endingEphemerisTime"] = getEndingTime(isd, parsingWarnings);
+  state["m_centerEphemerisTime"] = getCenterTime(isd, parsingWarnings.get());
+  state["m_startingEphemerisTime"] = getStartingTime(isd, parsingWarnings.get());
+  state["m_endingEphemerisTime"] = getEndingTime(isd, parsingWarnings.get());
 
-  state["m_exposureDuration"] = getExposureDuration(isd, parsingWarnings);
+  state["m_exposureDuration"] = getExposureDuration(isd, parsingWarnings.get());
 
   try {
     state["m_dtEphem"] = isd.at("dt_ephemeris");
@@ -85,31 +85,31 @@ string UsgsAstroSarSensorModel::constructStateFromIsd(
                      "UsgsAstroSarSensorModel::constructStateFromIsd()"));
   }
 
-  state["m_positions"] = getSensorPositions(isd, parsingWarnings);
-  state["m_velocities"] = getSensorVelocities(isd, parsingWarnings);
+  state["m_positions"] = getSensorPositions(isd, parsingWarnings.get());
+  state["m_velocities"] = getSensorVelocities(isd, parsingWarnings.get());
 
   state["m_currentParameterValue"] = vector<double>(NUM_PARAMETERS, 0.0);
 
   // get radii
-  state["m_minorAxis"] = getSemiMinorRadius(isd, parsingWarnings);
-  state["m_majorAxis"] = getSemiMajorRadius(isd, parsingWarnings);
+  state["m_minorAxis"] = getSemiMinorRadius(isd, parsingWarnings.get());
+  state["m_majorAxis"] = getSemiMajorRadius(isd, parsingWarnings.get());
 
   // set identifiers
-  state["m_platformIdentifier"] = getPlatformName(isd, parsingWarnings);
-  state["m_sensorIdentifier"] = getSensorName(isd, parsingWarnings);
+  state["m_platformIdentifier"] = getPlatformName(isd, parsingWarnings.get());
+  state["m_sensorIdentifier"] = getSensorName(isd, parsingWarnings.get());
 
   // get reference_height
   state["m_minElevation"] = -1000;
   state["m_maxElevation"] = 1000;
 
   // SAR specific values
-  state["m_scaledPixelWidth"] = getScaledPixelWidth(isd, parsingWarnings);
+  state["m_scaledPixelWidth"] = getScaledPixelWidth(isd, parsingWarnings.get());
   state["m_scaleConversionCoefficients"] =
-      getScaleConversionCoefficients(isd, parsingWarnings);
+      getScaleConversionCoefficients(isd, parsingWarnings.get());
   state["m_scaleConversionTimes"] =
-      getScaleConversionTimes(isd, parsingWarnings);
-  state["m_wavelength"] = getWavelength(isd, parsingWarnings);
-  state["m_lookDirection"] = getLookDirection(isd, parsingWarnings);
+      getScaleConversionTimes(isd, parsingWarnings.get());
+  state["m_wavelength"] = getWavelength(isd, parsingWarnings.get());
+  state["m_lookDirection"] = getLookDirection(isd, parsingWarnings.get());
 
   // Default to identity covariance
   state["m_covariance"] = vector<double>(NUM_PARAMETERS * NUM_PARAMETERS, 0.0);
@@ -127,15 +127,10 @@ string UsgsAstroSarSensorModel::constructStateFromIsd(
     csm::Warning warn = parsingWarnings->front();
     message += warn.getMessage();
     message += "]";
-    parsingWarnings = nullptr;
-    delete parsingWarnings;
     MESSAGE_LOG(message);
     throw csm::Error(csm::Error::SENSOR_MODEL_NOT_CONSTRUCTIBLE, message,
                      "UsgsAstroSarSensorModel::constructStateFromIsd");
   }
-
-  delete parsingWarnings;
-  parsingWarnings = nullptr;
 
   // The state data will still be updated when a sensor model is created since
   // some state data is not in the ISD and requires a SM to compute them.

--- a/tests/FrameCameraTests.cpp
+++ b/tests/FrameCameraTests.cpp
@@ -184,8 +184,8 @@ TEST_F(OrbitalFrameSensorModel, ImageToProximateImagingLocus) {
 TEST_F(FrameStateTest, FL500_OffBody4) {
   std::string key = "m_focalLength";
   double newValue = 500.0;
-  UsgsAstroFrameSensorModel* sensorModel =
-      createModifiedStateSensorModel(key, newValue);
+  std::shared_ptr<UsgsAstroFrameSensorModel> sensorModel(
+      createModifiedStateSensorModel(key, newValue));
 
   ASSERT_NE(sensorModel, nullptr);
   csm::ImageCoord imagePt(15.0, 15.0);
@@ -193,16 +193,13 @@ TEST_F(FrameStateTest, FL500_OffBody4) {
   EXPECT_NEAR(groundPt.x, 9.77688917, 1e-8);
   EXPECT_NEAR(groundPt.y, -1.48533467, 1e-8);
   EXPECT_NEAR(groundPt.z, -1.48533467, 1e-8);
-
-  delete sensorModel;
-  sensorModel = NULL;
 }
 
 TEST_F(FrameStateTest, FL500_OffBody3) {
   std::string key = "m_focalLength";
   double newValue = 500.0;
-  UsgsAstroFrameSensorModel* sensorModel =
-      createModifiedStateSensorModel(key, newValue);
+  std::shared_ptr<UsgsAstroFrameSensorModel> sensorModel(
+      createModifiedStateSensorModel(key, newValue));
 
   ASSERT_NE(sensorModel, nullptr);
   csm::ImageCoord imagePt(0.0, 0.0);
@@ -210,16 +207,13 @@ TEST_F(FrameStateTest, FL500_OffBody3) {
   EXPECT_NEAR(groundPt.x, 9.77688917, 1e-8);
   EXPECT_NEAR(groundPt.y, 1.48533467, 1e-8);
   EXPECT_NEAR(groundPt.z, 1.48533467, 1e-8);
-
-  delete sensorModel;
-  sensorModel = NULL;
 }
 
 TEST_F(FrameStateTest, FL500_Center) {
   std::string key = "m_focalLength";
   double newValue = 500.0;
-  UsgsAstroFrameSensorModel* sensorModel =
-      createModifiedStateSensorModel(key, newValue);
+  std::shared_ptr<UsgsAstroFrameSensorModel> sensorModel(
+      createModifiedStateSensorModel(key, newValue));
 
   ASSERT_NE(sensorModel, nullptr);
   csm::ImageCoord imagePt(7.5, 7.5);
@@ -227,16 +221,13 @@ TEST_F(FrameStateTest, FL500_Center) {
   EXPECT_NEAR(groundPt.x, 10.0, 1e-8);
   EXPECT_NEAR(groundPt.y, 0.0, 1e-8);
   EXPECT_NEAR(groundPt.z, 0.0, 1e-8);
-
-  delete sensorModel;
-  sensorModel = NULL;
 }
 
 TEST_F(FrameStateTest, FL500_SlightlyOffCenter) {
   std::string key = "m_focalLength";
   double newValue = 500.0;
-  UsgsAstroFrameSensorModel* sensorModel =
-      createModifiedStateSensorModel(key, newValue);
+  std::shared_ptr<UsgsAstroFrameSensorModel> sensorModel(
+      createModifiedStateSensorModel(key, newValue));
 
   ASSERT_NE(sensorModel, nullptr);
   csm::ImageCoord imagePt(7.5, 6.5);
@@ -244,9 +235,6 @@ TEST_F(FrameStateTest, FL500_SlightlyOffCenter) {
   EXPECT_NEAR(groundPt.x, 9.99803960, 1e-8);
   EXPECT_NEAR(groundPt.y, 0.0, 1e-8);
   EXPECT_NEAR(groundPt.z, 1.98000392e-01, 1e-8);
-
-  delete sensorModel;
-  sensorModel = NULL;
 }
 
 // Ellipsoid axis tests:
@@ -254,8 +242,8 @@ TEST_F(FrameStateTest, SemiMajorAxis100x_Center) {
   std::string key = "m_majorAxis";
   double newValue = 1000.0;
 
-  UsgsAstroFrameSensorModel* sensorModel =
-      createModifiedStateSensorModel(key, newValue);
+  std::shared_ptr<UsgsAstroFrameSensorModel> sensorModel(
+      createModifiedStateSensorModel(key, newValue));
 
   ASSERT_NE(sensorModel, nullptr);
   csm::ImageCoord imagePt(7.5, 7.5);
@@ -263,16 +251,13 @@ TEST_F(FrameStateTest, SemiMajorAxis100x_Center) {
   EXPECT_NEAR(groundPt.x, 1000.0, 1e-8);
   EXPECT_NEAR(groundPt.y, 0.0, 1e-8);
   EXPECT_NEAR(groundPt.z, 0.0, 1e-8);
-
-  delete sensorModel;
-  sensorModel = NULL;
 }
 
 TEST_F(FrameStateTest, SemiMajorAxis10x_SlightlyOffCenter) {
   std::string key = "m_majorAxis";
   double newValue = 100.0;
-  UsgsAstroFrameSensorModel* sensorModel =
-      createModifiedStateSensorModel(key, newValue);
+  std::shared_ptr<UsgsAstroFrameSensorModel> sensorModel(
+      createModifiedStateSensorModel(key, newValue));
 
   ASSERT_NE(sensorModel, nullptr);
   csm::ImageCoord imagePt(7.5, 6.5);
@@ -283,9 +268,6 @@ TEST_F(FrameStateTest, SemiMajorAxis10x_SlightlyOffCenter) {
   EXPECT_NEAR(groundPt.x, 9.83606557e+01, 1e-7);
   EXPECT_NEAR(groundPt.y, 0.0, 1e-7);
   EXPECT_NEAR(groundPt.z, 1.80327869, 1e-7);
-
-  delete sensorModel;
-  sensorModel = NULL;
 }
 
 // The following test is for the scenario where the semi_minor_axis is actually
@@ -293,8 +275,8 @@ TEST_F(FrameStateTest, SemiMajorAxis10x_SlightlyOffCenter) {
 TEST_F(FrameStateTest, SemiMinorAxis10x_SlightlyOffCenter) {
   std::string key = "m_minorAxis";
   double newValue = 100.0;
-  UsgsAstroFrameSensorModel* sensorModel =
-      createModifiedStateSensorModel(key, newValue);
+  std::shared_ptr<UsgsAstroFrameSensorModel> sensorModel(
+      createModifiedStateSensorModel(key, newValue));
 
   ASSERT_NE(sensorModel, nullptr);
   csm::ImageCoord imagePt(7.5, 6.5);
@@ -302,16 +284,13 @@ TEST_F(FrameStateTest, SemiMinorAxis10x_SlightlyOffCenter) {
   EXPECT_NEAR(groundPt.x, 9.99803960, 1e-8);
   EXPECT_NEAR(groundPt.y, 0.0, 1e-8);
   EXPECT_NEAR(groundPt.z, 1.98000392, 1e-8);
-
-  delete sensorModel;
-  sensorModel = NULL;
 }
 
 TEST_F(FrameStateTest, SampleSumming) {
   std::string key = "m_detectorSampleSumming";
   double newValue = 2.0;
-  UsgsAstroFrameSensorModel* sensorModel =
-      createModifiedStateSensorModel(key, newValue);
+  std::shared_ptr<UsgsAstroFrameSensorModel> sensorModel(
+      createModifiedStateSensorModel(key, newValue));
 
   ASSERT_NE(sensorModel, nullptr);
   csm::ImageCoord imagePt(7.5, 3.75);
@@ -319,16 +298,13 @@ TEST_F(FrameStateTest, SampleSumming) {
   EXPECT_NEAR(groundPt.x, 10.0, 1e-8);
   EXPECT_NEAR(groundPt.y, 0, 1e-8);
   EXPECT_NEAR(groundPt.z, 0, 1e-8);
-
-  delete sensorModel;
-  sensorModel = NULL;
 }
 
 TEST_F(FrameStateTest, LineSumming) {
   std::string key = "m_detectorLineSumming";
   double newValue = 2.0;
-  UsgsAstroFrameSensorModel* sensorModel =
-      createModifiedStateSensorModel(key, newValue);
+  std::shared_ptr<UsgsAstroFrameSensorModel> sensorModel(
+      createModifiedStateSensorModel(key, newValue));
 
   ASSERT_NE(sensorModel, nullptr);
   csm::ImageCoord imagePt(3.75, 7.5);
@@ -336,16 +312,13 @@ TEST_F(FrameStateTest, LineSumming) {
   EXPECT_NEAR(groundPt.x, 10.0, 1e-8);
   EXPECT_NEAR(groundPt.y, 0, 1e-8);
   EXPECT_NEAR(groundPt.z, 0, 1e-8);
-
-  delete sensorModel;
-  sensorModel = NULL;
 }
 
 TEST_F(FrameStateTest, StartSample) {
   std::string key = "m_startingDetectorSample";
   double newValue = 5.0;
-  UsgsAstroFrameSensorModel* sensorModel =
-      createModifiedStateSensorModel(key, newValue);
+  std::shared_ptr<UsgsAstroFrameSensorModel> sensorModel(
+      createModifiedStateSensorModel(key, newValue));
 
   ASSERT_NE(sensorModel, nullptr);
   csm::ImageCoord imagePt(7.5, 2.5);
@@ -353,16 +326,13 @@ TEST_F(FrameStateTest, StartSample) {
   EXPECT_NEAR(groundPt.x, 10.0, 1e-8);
   EXPECT_NEAR(groundPt.y, 0, 1e-8);
   EXPECT_NEAR(groundPt.z, 0, 1e-8);
-
-  delete sensorModel;
-  sensorModel = NULL;
 }
 
 TEST_F(FrameStateTest, StartLine) {
   std::string key = "m_startingDetectorLine";
   double newValue = 5.0;
-  UsgsAstroFrameSensorModel* sensorModel =
-      createModifiedStateSensorModel(key, newValue);
+  std::shared_ptr<UsgsAstroFrameSensorModel> sensorModel(
+      createModifiedStateSensorModel(key, newValue));
 
   ASSERT_NE(sensorModel, nullptr);
   csm::ImageCoord imagePt(2.5, 7.5);
@@ -370,9 +340,6 @@ TEST_F(FrameStateTest, StartLine) {
   EXPECT_NEAR(groundPt.x, 10.0, 1e-8);
   EXPECT_NEAR(groundPt.y, 0, 1e-8);
   EXPECT_NEAR(groundPt.z, 0, 1e-8);
-
-  delete sensorModel;
-  sensorModel = NULL;
 }
 
 // ****************************************************************************
@@ -390,9 +357,6 @@ TEST_F(FrameSensorModel, X10_SlightlyOffCenter) {
   EXPECT_NEAR(groundPt.x, 10.0, 1e-8);
   EXPECT_NEAR(groundPt.y, 0.0, 1e-8);
   EXPECT_NEAR(groundPt.z, 0.0, 1e-8);
-
-  delete sensorModel;
-  sensorModel = NULL;
 }
 
 TEST_F(FrameSensorModel, X1e9_SlightlyOffCenter) {
@@ -407,9 +371,6 @@ TEST_F(FrameSensorModel, X1e9_SlightlyOffCenter) {
   EXPECT_NEAR(groundPt.x, 3.99998400e+03, 1e-4);
   EXPECT_NEAR(groundPt.y, 0.0, 1e-4);
   EXPECT_NEAR(groundPt.z, 1.99999200e+06, 1e-4);
-
-  delete sensorModel;
-  sensorModel = NULL;
 }
 
 // Angle rotations:
@@ -430,9 +391,6 @@ TEST_F(FrameSensorModel, Rotation_omegaPi_Center) {
   EXPECT_NEAR(groundPt.x, -10.0, 1e-8);
   EXPECT_NEAR(groundPt.y, 0.0, 1e-8);
   EXPECT_NEAR(groundPt.z, 0.0, 1e-8);
-
-  delete sensorModel;
-  sensorModel = NULL;
 }
 
 TEST_F(FrameSensorModel, Rotation_NPole_Center) {
@@ -452,9 +410,6 @@ TEST_F(FrameSensorModel, Rotation_NPole_Center) {
   EXPECT_NEAR(groundPt.x, 0.0, 1e-8);
   EXPECT_NEAR(groundPt.y, 0.0, 1e-8);
   EXPECT_NEAR(groundPt.z, 10.0, 1e-8);
-
-  delete sensorModel;
-  sensorModel = NULL;
 }
 
 TEST_F(FrameSensorModel, Rotation_SPole_Center) {
@@ -469,9 +424,6 @@ TEST_F(FrameSensorModel, Rotation_SPole_Center) {
   EXPECT_NEAR(groundPt.x, 0.0, 1e-8);
   EXPECT_NEAR(groundPt.y, 0.0, 1e-8);
   EXPECT_NEAR(groundPt.z, -10.0, 1e-8);
-
-  delete sensorModel;
-  sensorModel = NULL;
 }
 
 // ****************************************************************************

--- a/tests/PluginTests.cpp
+++ b/tests/PluginTests.cpp
@@ -93,32 +93,25 @@ TEST_F(FrameIsdTest, NotConstructible) {
 
 TEST_F(FrameIsdTest, ConstructValidCamera) {
   UsgsAstroPlugin testPlugin;
-  csm::Model *cameraModel = NULL;
-  EXPECT_NO_THROW(cameraModel = testPlugin.constructModelFromISD(
-                      isd, "USGS_ASTRO_FRAME_SENSOR_MODEL", NULL));
+  std::shared_ptr<csm::Model> cameraModel(NULL);
+  EXPECT_NO_THROW(cameraModel = std::shared_ptr<csm::Model>(testPlugin.constructModelFromISD
+                                                            (isd, "USGS_ASTRO_FRAME_SENSOR_MODEL", NULL)));
   UsgsAstroFrameSensorModel *frameModel =
-      dynamic_cast<UsgsAstroFrameSensorModel *>(cameraModel);
+    dynamic_cast<UsgsAstroFrameSensorModel *>(cameraModel.get());
   EXPECT_NE(frameModel, nullptr);
-  if (cameraModel) {
-    delete cameraModel;
-  }
 }
 
-TEST_F(FrameIsdTest, ConstructInValidCamera) {
+TEST_F(FrameIsdTest, ConstructInvalidCamera) {
   UsgsAstroPlugin testPlugin;
   isd.setFilename("data/empty.img");
-  csm::Model *cameraModel = NULL;
+  std::shared_ptr<csm::Model> cameraModel(NULL);
   try {
-    testPlugin.constructModelFromISD(isd, "USGS_ASTRO_FRAME_SENSOR_MODEL",
-                                     nullptr);
+    cameraModel = std::shared_ptr<csm::Model>(testPlugin.constructModelFromISD(isd, "USGS_ASTRO_FRAME_SENSOR_MODEL", nullptr));
     FAIL() << "Expected an error";
   } catch (csm::Error &e) {
     EXPECT_EQ(e.getError(), csm::Error::SENSOR_MODEL_NOT_CONSTRUCTIBLE);
   } catch (...) {
     FAIL() << "Expected csm SENSOR_MODEL_NOT_CONSTRUCTIBLE error";
-  }
-  if (cameraModel) {
-    delete cameraModel;
   }
 }
 
@@ -144,34 +137,28 @@ TEST_F(ConstVelLineScanIsdTest, NotConstructible) {
 
 TEST_F(ConstVelLineScanIsdTest, ConstructValidCamera) {
   UsgsAstroPlugin testPlugin;
-  csm::Model *cameraModel = NULL;
-  EXPECT_NO_THROW(cameraModel = testPlugin.constructModelFromISD(
-                      isd, "USGS_ASTRO_LINE_SCANNER_SENSOR_MODEL", NULL));
+  std::shared_ptr<csm::Model> cameraModel(NULL);
+  EXPECT_NO_THROW(cameraModel = std::shared_ptr<csm::Model>(testPlugin.constructModelFromISD
+                                                            (isd, "USGS_ASTRO_LINE_SCANNER_SENSOR_MODEL", NULL)));
   UsgsAstroLsSensorModel *frameModel =
-      dynamic_cast<UsgsAstroLsSensorModel *>(cameraModel);
+    dynamic_cast<UsgsAstroLsSensorModel *>(cameraModel.get());
   EXPECT_NE(frameModel, nullptr);
-  if (cameraModel) {
-    delete cameraModel;
-  }
 }
 
-TEST_F(ConstVelLineScanIsdTest, ConstructInValidCamera) {
+TEST_F(ConstVelLineScanIsdTest, ConstructInvalidCamera) {
   UsgsAstroPlugin testPlugin;
   isd.setFilename("data/empty.img");
   csm::Model *cameraModel = NULL;
   try {
-    testPlugin.constructModelFromISD(
-        isd, "USGS_ASTRO_LINE_SCANNER_SENSOR_MODEL", nullptr);
+    std::shared_ptr<csm::Model> cameraModel(testPlugin.constructModelFromISD
+                                            (isd, "USGS_ASTRO_LINE_SCANNER_SENSOR_MODEL", nullptr));
     FAIL() << "Expected an error";
-
   } catch (csm::Error &e) {
     EXPECT_EQ(e.getError(), csm::Error::SENSOR_MODEL_NOT_CONSTRUCTIBLE);
   } catch (...) {
     FAIL() << "Expected csm SENSOR_MODEL_NOT_CONSTRUCTIBLE error";
   }
-  if (cameraModel) {
-    delete cameraModel;
-  }
+  
 }
 
 TEST_F(SarIsdTest, Constructible) {
@@ -207,37 +194,30 @@ TEST_F(SarIsdTest, NotConstructible) {
 TEST_F(SarIsdTest, ConstructValidCamera) {
   UsgsAstroPlugin testPlugin;
   csm::WarningList warnings;
-  csm::Model *cameraModel = NULL;
-  EXPECT_NO_THROW(cameraModel = testPlugin.constructModelFromISD(
-                      isd, "USGS_ASTRO_SAR_SENSOR_MODEL", &warnings));
+  std::shared_ptr<csm::Model> cameraModel(NULL);
+  EXPECT_NO_THROW(cameraModel =  std::shared_ptr<csm::Model>(testPlugin.constructModelFromISD
+                                                             (isd, "USGS_ASTRO_SAR_SENSOR_MODEL", &warnings)));
   for (auto &warn : warnings) {
     std::cerr << "Warning in " << warn.getFunction() << std::endl;
     std::cerr << "  " << warn.getMessage() << std::endl;
   }
   UsgsAstroSarSensorModel *sarModel =
-      dynamic_cast<UsgsAstroSarSensorModel *>(cameraModel);
+    dynamic_cast<UsgsAstroSarSensorModel *>(cameraModel.get());
   EXPECT_NE(sarModel, nullptr);
-  if (cameraModel) {
-    delete cameraModel;
-  }
 }
 
-TEST_F(SarIsdTest, ConstructInValidCamera) {
+TEST_F(SarIsdTest, ConstructInvalidCamera) {
   UsgsAstroPlugin testPlugin;
   isd.setFilename("data/empty.img");
-  csm::Model *cameraModel = NULL;
+  std::shared_ptr<csm::Model> cameraModel(NULL);
   try {
-    testPlugin.constructModelFromISD(isd, "USGS_ASTRO_SAR_SENSOR_MODEL",
-                                     nullptr);
+    cameraModel = std::shared_ptr<csm::Model>(testPlugin.constructModelFromISD(isd, "USGS_ASTRO_SAR_SENSOR_MODEL", nullptr));
     FAIL() << "Expected an error";
 
   } catch (csm::Error &e) {
     EXPECT_EQ(e.getError(), csm::Error::SENSOR_MODEL_NOT_CONSTRUCTIBLE);
   } catch (...) {
     FAIL() << "Expected csm SENSOR_MODEL_NOT_CONSTRUCTIBLE error";
-  }
-  if (cameraModel) {
-    delete cameraModel;
   }
 }
 


### PR DESCRIPTION
This replaces some bare pointers with smart pointers where the API allows for it. This is less error-prone. In fact, I think I found a little bug here: 

https://github.com/oleg-alexandrov/usgscsm/commit/4a99a074204a946be7d71cde55c7b2fd412752d0#diff-f900e8fad537ea95223efd435687144ea33ba3ee546fab412522f91e74fdc61fL130

where a pointer was first assigned to null and then deleted, which would mean the memory was actually not deallocated. 