### PR TITLE
Speedup in Linescan model by avoiding unneeded computations

### DIFF
--- a/include/usgscsm/UsgsAstroLsSensorModel.h
+++ b/include/usgscsm/UsgsAstroLsSensorModel.h
@@ -953,7 +953,9 @@ class UsgsAstroLsSensorModel : public csm::RasterGM,
                              const double& desired_precision,
                              csm::WarningList* warnings = NULL) const;
 
-  // determines the sensor velocity accounting for parameter adjustments.
+  // Determines the sensor position and velocity accounting for
+  // parameter adjustments. Use calc_vel = false if the velocity is
+  // not needed.
   void getAdjSensorPosVel(const double& time, const std::vector<double>& adj,
                           double& xc, double& yc, double& zc, double& vx,
                           double& vy, double& vz, bool calc_vel = true) const;

--- a/include/usgscsm/UsgsAstroLsSensorModel.h
+++ b/include/usgscsm/UsgsAstroLsSensorModel.h
@@ -956,7 +956,7 @@ class UsgsAstroLsSensorModel : public csm::RasterGM,
   // determines the sensor velocity accounting for parameter adjustments.
   void getAdjSensorPosVel(const double& time, const std::vector<double>& adj,
                           double& xc, double& yc, double& zc, double& vx,
-                          double& vy, double& vz) const;
+                          double& vy, double& vz, bool calc_vel = true) const;
 
   // Computes the imaging locus that would view a ground point at a specific
   // time. Computationally, this is the opposite of losToEcf.

--- a/src/UsgsAstroLsSensorModel.cpp
+++ b/src/UsgsAstroLsSensorModel.cpp
@@ -1943,21 +1943,27 @@ void UsgsAstroLsSensorModel::getAdjSensorPosVel(const double& time,
                  time, 3, nOrder, sensPosNom);
 
   // Avoid computing the velocity and adjustments, if not needed, as those
-  // take up at least half of this function's time.
-  bool has_adj = false;
-  for (size_t it = 0; it < adj.size(); it++) {
-    if (adj[it] != 0) {
-      has_adj = true;
+  // take up at least half of this function's time. Note that if the
+  // adjustments are non-null, need to compute the velocity in order
+  // to find the adjusted position.
+  if (!calc_vel) {
+    bool has_adj = false;
+    for (size_t it = 0; it < adj.size(); it++) {
+      if (adj[it] != 0) has_adj = true;
     }
-  }
-  if (!has_adj && !calc_vel) {
-    xc = sensPosNom[0];
-    yc = sensPosNom[1];
-    zc = sensPosNom[2];
-    vx = 0.0;
-    vy = 0.0;
-    vz = 0.0;
-    return;
+    if (!has_adj) {
+      xc = sensPosNom[0];
+      yc = sensPosNom[1];
+      zc = sensPosNom[2];
+      vx = 0.0;
+      vy = 0.0;
+      vz = 0.0;
+
+      MESSAGE_LOG("getAdjSensorPosVel: postition {} {} {}"
+                  "and velocity {} {} {}",
+                  xc, yc, zc, vx, vy, vz)
+        return;
+    }
   }
   
   double sensVelNom[3];


### PR DESCRIPTION
I made a 23% speed improvement in the linescan sensor logic, without changing the results. This relies on avoiding computing the interpolated velocity and applying adjustments when those are not used by the caller.

To verify this, run:

cd usgscsm/build
time ./usgscsm_cam_test --model ../tests/data/toughLroNacLineScan.json --sample-rate 1

before and after applying the fix. On my machine the run time is 155 seconds before the fix, and 118 seconds after it. Granted, not a huge improvement, but it is notable, and the code changes are small.
