### PR TITLE
Add an initial projective approximation for linescan camera

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,9 @@ if(USGSCSM_EXTERNAL_DEPS)
   # Nlohmann JSON
   find_package(nlohmann_json REQUIRED)
 
+  # Eigen
+  find_package(Eigen3 3.3 REQUIRED NO_MODULE)
+   
   # ALE
   find_package(ale REQUIRED)
   set(ALE_TARGET ale::ale)
@@ -53,8 +56,11 @@ else()
   set(ALE_BUILD_TESTS OFF)
   add_subdirectory(ale)
   set(ALE_TARGET ale)
-endif(USGSCSM_EXTERNAL_DEPS)
 
+  # Use Eigen included with ALE
+  add_library (Eigen3::Eigen ALIAS eigen)
+  set(EIGEN3_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/ale/eigen)
+endif(USGSCSM_EXTERNAL_DEPS)
 
 add_library(usgscsm SHARED
             src/UsgsAstroPlugin.cpp
@@ -63,7 +69,8 @@ add_library(usgscsm SHARED
             src/UsgsAstroLsSensorModel.cpp
             src/UsgsAstroSarSensorModel.cpp
             src/Distortion.cpp
-            src/Utilities.cpp)
+            src/Utilities.cpp
+            src/EigenUtilities.cpp)
 
 set_target_properties(usgscsm PROPERTIES
     VERSION ${PROJECT_VERSION}
@@ -71,7 +78,8 @@ set_target_properties(usgscsm PROPERTIES
 )
 
 set(USGSCSM_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include/usgscsm"
-                         "${CMAKE_CURRENT_SOURCE_DIR}/include/")
+                         "${CMAKE_CURRENT_SOURCE_DIR}/include"
+                         "${EIGEN3_INCLUDE_DIR}")
 
 target_include_directories(usgscsm
                            PUBLIC

--- a/environment.yml
+++ b/environment.yml
@@ -8,3 +8,4 @@ dependencies:
   - ale
   - csm
   - nlohmann_json
+  - eigen

--- a/include/usgscsm/EigenUtilities.h
+++ b/include/usgscsm/EigenUtilities.h
@@ -8,8 +8,8 @@
 
 namespace usgscsm {
   
-// Compute the best-fitting projective transform that maps ground
-// points to image points.
+// Compute the best-fitting projective transform that maps a set of 3D points
+// to 2D points.
 void computeBestFitProjectiveTransform(std::vector<csm::ImageCoord> const& imagePts,
                                        std::vector<csm::EcefCoord>  const& groundPts,
                                        std::vector<double> & transformCoeffs);

--- a/include/usgscsm/EigenUtilities.h
+++ b/include/usgscsm/EigenUtilities.h
@@ -1,0 +1,17 @@
+#ifndef INCLUDE_USGSCSM_EIGENUTILITIES_H_
+#define INCLUDE_USGSCSM_EIGENUTILITIES_H_
+
+// Do not include Eigen header files here as those will slow down the compilation
+// whereever this header file is included.
+
+#include <csm.h>
+
+namespace usgscsm {
+  
+// Compute the best-fitting projective transform that maps ground
+// points to image points.
+void computeBestFitProjectiveTransform(std::vector<csm::ImageCoord> const& imagePts,
+                                       std::vector<csm::EcefCoord>  const& groundPts,
+                                       std::vector<double> & transformCoeffs);
+}
+#endif  // INCLUDE_USGSCSM_EIGENUTILITIES_H_

--- a/include/usgscsm/UsgsAstroLsSensorModel.h
+++ b/include/usgscsm/UsgsAstroLsSensorModel.h
@@ -968,14 +968,6 @@ class UsgsAstroLsSensorModel : public csm::RasterGM,
       const std::vector<double>& adj)      // Parameter Adjustments for partials
       const;
 
-  // The linear approximation for the sensor model is used as the starting point
-  // for iterative rigorous calculations.
-  void computeLinearApproximation(const csm::EcefCoord& gp,
-                                  csm::ImageCoord& ip) const;
-
-  // Create the linear approximation to be used at each ground point
-  void createLinearApproximation();
-
   // The projective approximation for the sensor model is used as the starting point
   // for iterative rigorous calculations.
   void computeProjectiveApproximation(const csm::EcefCoord& gp,
@@ -983,9 +975,6 @@ class UsgsAstroLsSensorModel : public csm::RasterGM,
   
   // Create the projective approximation to be used at each ground point
   void createProjectiveApproximation();
-
-  // Compute the determinant of a 3x3 matrix
-  double determinant3x3(double mat[9]) const;
   
   // A function whose value will be 0 when the line a given ground
   // point projects into is found. The obtained line will be
@@ -996,23 +985,12 @@ class UsgsAstroLsSensorModel : public csm::RasterGM,
   
   csm::NoCorrelationModel _no_corr_model;  // A way to report no correlation
                                            // between images is supported
-  std::vector<double>
-      _no_adjustment;  // A vector of zeros indicating no internal adjustment
-
-  // Store here the linear approximation of the sensor model
-  double _u0;
-  double _du_dx;
-  double _du_dy;
-  double _du_dz;
-  double _v0;
-  double _dv_dx;
-  double _dv_dy;
-  double _dv_dz;
+  std::vector<double> _no_adjustment;  // A vector of zeros indicating no internal adjustment
 
   // Store here the projective approximation of the sensor model
   std::vector<double> m_projTransCoeffs; 
 
-  // Flag indicating if an initial approximation of some kind is used
+  // Flag indicating if an initial approximation is used
   bool m_useApproxInitTrans;
 };
 

--- a/include/usgscsm/UsgsAstroLsSensorModel.h
+++ b/include/usgscsm/UsgsAstroLsSensorModel.h
@@ -973,8 +973,16 @@ class UsgsAstroLsSensorModel : public csm::RasterGM,
   void computeLinearApproximation(const csm::EcefCoord& gp,
                                   csm::ImageCoord& ip) const;
 
-  // Initial setup of the linear approximation
-  void setLinearApproximation();
+  // Create the linear approximation to be used at each ground point
+  void createLinearApproximation();
+
+  // The projective approximation for the sensor model is used as the starting point
+  // for iterative rigorous calculations.
+  void computeProjectiveApproximation(const csm::EcefCoord& gp,
+                                      csm::ImageCoord& ip) const;
+  
+  // Create the projective approximation to be used at each ground point
+  void createProjectiveApproximation();
 
   // Compute the determinant of a 3x3 matrix
   double determinant3x3(double mat[9]) const;
@@ -991,7 +999,7 @@ class UsgsAstroLsSensorModel : public csm::RasterGM,
   std::vector<double>
       _no_adjustment;  // A vector of zeros indicating no internal adjustment
 
-  // The following support the linear approximation of the sensor model
+  // Store here the linear approximation of the sensor model
   double _u0;
   double _du_dx;
   double _du_dy;
@@ -1000,7 +1008,12 @@ class UsgsAstroLsSensorModel : public csm::RasterGM,
   double _dv_dx;
   double _dv_dy;
   double _dv_dz;
-  bool _linear;  // flag indicating if linear approximation is useful.
+
+  // Store here the projective approximation of the sensor model
+  std::vector<double> m_projTransCoeffs; 
+
+  // Flag indicating if an initial approximation of some kind is used
+  bool m_useApproxInitTrans;
 };
 
 #endif  // INCLUDE_USGSCSM_USGSASTROLSSENSORMODEL_H_

--- a/src/EigenUtilities.cpp
+++ b/src/EigenUtilities.cpp
@@ -56,18 +56,6 @@ void usgscsm::computeBestFitProjectiveTransform(std::vector<csm::ImageCoord> con
   // https://eigen.tuxfamily.org/dox/group__LeastSquares.html
   Eigen::VectorXd u = M.colPivHouseholderQr().solve(b);
 
-#if 0
-  // Verification
-  for (int it = 0; it < numPts; it++) {
-
-    double x = groundPts[it].x, y = groundPts[it].y, z = groundPts[it].z;
-    double r = imagePts[it].line, c = imagePts[it].samp;
- 
-    double r2 = (u[0] + u[1] * x + u[2] * y + u[3]  * z) / (1 + u[4]  * x + u[5]  * y + u[6]  * z);
-    double c2 = (u[7] + u[8] * x + u[9] * y + u[10] * z) / (1 + u[11] * x + u[12] * y + u[13] * z);
-  }
-#endif
-  
   // Copy back the result to a standard vector (to avoid using Eigen too much as
   // that is slow to compile).
   transformCoeffs.resize(numMatCols);

--- a/src/EigenUtilities.cpp
+++ b/src/EigenUtilities.cpp
@@ -1,0 +1,75 @@
+#include "EigenUtilities.h"
+
+#include <csm/Error.h>
+#include <Eigen/Dense>
+
+#include <iostream>
+
+// Keep these utilities separate as using Eigen in an existing source
+// file results in a 50% increase in compilation time.
+
+// Compute the best-fitting projective transform that maps ground
+// points to image points.
+void usgscsm::computeBestFitProjectiveTransform(std::vector<csm::ImageCoord> const& imagePts,
+                                                std::vector<csm::EcefCoord>  const& groundPts,
+                                                std::vector<double> & transformCoeffs) {
+  
+  if (imagePts.size() != groundPts.size()) 
+    throw csm::Error(csm::Error::INVALID_USE,
+                     "The number of inputs and outputs must agree.",
+                     "computeBestFitProjectiveTransform");
+  
+  int numPts = imagePts.size();
+  if (numPts < 8)
+    throw csm::Error(csm::Error::INVALID_USE,
+                     "At least 8 points are needed to fit a 3D-to-2D projective transform. "
+                     "Ideally more are preferred.",
+                     "computeBestFitProjectiveTransform");
+
+  int numMatRows = 2 * numPts; // there exist x and y coords for each point
+  int numMatCols = 14; // Number of variables in the projective transform
+  
+  Eigen::MatrixXd M = Eigen::MatrixXd::Zero(numMatRows, numMatCols);
+  Eigen::VectorXd b = Eigen::VectorXd::Zero(numMatRows);
+  
+  for (int it = 0; it < numPts; it++) {
+
+    double x = groundPts[it].x, y = groundPts[it].y, z = groundPts[it].z;
+    double r = imagePts[it].line, c = imagePts[it].samp;
+
+    // If the solution coefficients are u0, u1, ..., must have:
+ 
+    // (u0 + u1 * x + u2 * y + u3  * z) / (1 + u4  * x + u5  * y + u6  * z) = r
+    // (u7 + u8 * x + u9 * y + u10 * z) / (1 + u11 * x + u12 * y + u13 * z) = c
+    
+    M.row(2 * it + 0) << 1, x, y, z, -x * r, -y * r, -z * r, 0, 0, 0, 0, 0, 0, 0;
+    M.row(2 * it + 1) << 0, 0, 0, 0, 0, 0, 0, 1, x, y, z, -x * c, -y * c, -z * c;
+
+    b[2 * it + 0] = r;
+    b[2 * it + 1] = c;
+  }
+
+  // Solve the over-determined system, per:
+  // https://eigen.tuxfamily.org/dox/group__LeastSquares.html
+  Eigen::VectorXd u = M.colPivHouseholderQr().solve(b);
+
+#if 0
+  // Verification
+  for (int it = 0; it < numPts; it++) {
+
+    double x = groundPts[it].x, y = groundPts[it].y, z = groundPts[it].z;
+    double r = imagePts[it].line, c = imagePts[it].samp;
+ 
+    double r2 = (u[0] + u[1] * x + u[2] * y + u[3]  * z) / (1 + u[4]  * x + u[5]  * y + u[6]  * z);
+    double c2 = (u[7] + u[8] * x + u[9] * y + u[10] * z) / (1 + u[11] * x + u[12] * y + u[13] * z);
+  }
+#endif
+  
+  // Copy back the result to a standard vector (to avoid using Eigen too much as
+  // that is slow to compile).
+  transformCoeffs.resize(numMatCols);
+  for (int it = 0; it < numMatCols; it++)
+    transformCoeffs[it] = u[it];
+
+  return;
+} 

--- a/src/EigenUtilities.cpp
+++ b/src/EigenUtilities.cpp
@@ -1,6 +1,6 @@
 #include "EigenUtilities.h"
 
-#include <csm/Error.h>
+#include <Error.h>
 #include <Eigen/Dense>
 
 #include <iostream>
@@ -8,8 +8,9 @@
 // Keep these utilities separate as using Eigen in an existing source
 // file results in a 50% increase in compilation time.
 
-// Compute the best-fitting projective transform that maps ground
-// points to image points.
+// Compute the best-fitting projective transform that maps a set of 3D points
+// to 2D points.
+// A best-fit linear transform could be created by eliminating the denominators below.
 void usgscsm::computeBestFitProjectiveTransform(std::vector<csm::ImageCoord> const& imagePts,
                                                 std::vector<csm::EcefCoord>  const& groundPts,
                                                 std::vector<double> & transformCoeffs) {
@@ -41,6 +42,8 @@ void usgscsm::computeBestFitProjectiveTransform(std::vector<csm::ImageCoord> con
  
     // (u0 + u1 * x + u2 * y + u3  * z) / (1 + u4  * x + u5  * y + u6  * z) = r
     // (u7 + u8 * x + u9 * y + u10 * z) / (1 + u11 * x + u12 * y + u13 * z) = c
+
+    // Multiply by the denominators. Get a linear regression in the coefficients.
     
     M.row(2 * it + 0) << 1, x, y, z, -x * r, -y * r, -z * r, 0, 0, 0, 0, 0, 0, 0;
     M.row(2 * it + 1) << 0, 0, 0, 0, 0, 0, 0, 1, x, y, z, -x * c, -y * c, -z * c;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,7 +9,8 @@ add_executable(runCSMCameraModelTests
                DistortionTests.cpp
                SarTests.cpp
                ISDParsingTests.cpp
-               UtilitiesTests.cpp)
+               UtilitiesTests.cpp
+               EigenUtilitiesTests.cpp)
 if(WIN32)
   option(CMAKE_USE_WIN32_THREADS_INIT "using WIN32 threads" ON)
   option(gtest_disable_pthreads "Disable uses of pthreads in gtest." ON)

--- a/tests/EigenUtilitiesTests.cpp
+++ b/tests/EigenUtilitiesTests.cpp
@@ -1,0 +1,46 @@
+#include "EigenUtilities.h"
+
+#include <gtest/gtest.h>
+#include <cmath>
+
+// See if fitting a projective transform to points which were created
+// with such a transform to start with can recover it. 
+TEST(EigenUtilitiesTests, createProjectiveApproximation) {
+
+  // Create a projective transform with coeffs stored in a vector.
+  // The exact values are not important.
+  std::vector<double> u(14);
+  for (size_t it = 0; it < u.size(); it++) 
+    u[it] = sin(it); // why not
+  
+  // Create inputs and outputs
+  std::vector<csm::ImageCoord> imagePts;
+  std::vector<csm::EcefCoord>  groundPts;
+  for (int r = 0; r < 5; r++) {
+    for (int c = 0; c < 5; c++) {
+
+      // Create some 3D points. The precise values are not important
+      // as long as they are well-distributed
+      double x = c, y = r, z = 0.3 * x + 2 * y + 0.04 * x * y;
+      
+      // Find corresponding 2D points
+      double p = (u[0] + u[1] * x + u[2] * y + u[3]  * z) / (1 + u[4]  * x + u[5]  * y + u[6]  * z);
+      double q = (u[7] + u[8] * x + u[9] * y + u[10] * z) / (1 + u[11] * x + u[12] * y + u[13] * z);
+
+      imagePts.push_back(csm::ImageCoord(p, q));
+      groundPts.push_back(csm::EcefCoord(x, y, z));
+    }
+  }
+
+  // Find the transform
+  std::vector<double> transformCoeffs;
+  usgscsm::computeBestFitProjectiveTransform(imagePts, groundPts, transformCoeffs);
+
+  // Verify that we recover the transform
+  double err = 0.0;
+  for (size_t it = 0; it < u.size(); it++)
+    err = std::max(err, std::abs(u[it] - transformCoeffs[it]));
+  
+  EXPECT_NEAR(0.0, err, 1e-12);
+}
+


### PR DESCRIPTION
I implemented an initial guess ground-to-image function for the linecan model which is a projective transform, instead of the existing linear transform. The hope is that this makes more sense geometrically when it comes to projections into camera, so it would fit better the function we want. It is also not that nonlinear to be concerned about it doing funny things when out of range.

With the difficult LRO NAC dataset from the repo, the guessed line using this initial guess projective transform differs from the
eventual computed value of this line by 0.69 pixels.  Before, with the linear approximation, the discrepancy was 82.7 pixels.

With a CTX dataset, the mean line error was 160.4 pixels before, and is 0.85 pixels now.

This does not in a dramatic speed improvement though, because the secant method converges so fast even with a bad initial guess. For LRO NAC (when the sample rate in usgscsm_cam_test is 1) the runtime goes from 122 to 108 seconds, which is a 11% speedup, while for CTX it goes from 82 to 70 seconds, which is a 14% speedup (here I used sample rate of 2).

Anyhow, this is a noticeable improvement, verified with two different datasets, so it is not too bad. Likely there's only very limited room for further improvement by fitting a fancier transform.

A couple more notes. I made USGSCSM depend on Eigen, which is not a big deal, as ALE already depends on Eigen and USGSCSM depends on ALE. I tested that the code compiles fine with both internal and external dependencies.

Also, Eigen is a hog and can slow down compilation speed (from 30 to 45 seconds on my machine for the linescan class). For that reason I isolated the Eigen logic to a single .cpp file to avoid this.