### PR TITLE
Updated push frame to use secant frame search

### DIFF
--- a/include/usgscsm/UsgsAstroPushFrameSensorModel.h
+++ b/include/usgscsm/UsgsAstroPushFrameSensorModel.h
@@ -945,6 +945,12 @@ class UsgsAstroPushFrameSensorModel : public csm::RasterGM,
                             const csm::EcefCoord& groundPt,
                             const std::vector<double>& adj) const;
 
+  // Computes the line distance from the center of a frame to the image point
+  // that a ground point reprojects to at that frame.
+  double calcFrameDistance(int frameletNumber,
+                           const csm::EcefCoord& groundPt,
+                           const std::vector<double>& adj) const;
+
   csm::NoCorrelationModel _no_corr_model;  // A way to report no correlation
                                            // between images is supported
   std::vector<double>


### PR DESCRIPTION
The old code was doing a binary search using the sensor distance. This worked when the observation was perfectly nadir, but when the observation is off-nadir, we want to instead find the frame where the ground point is observed closest to the center of the frame.