### PR TITLE
Initial frame jitter

### DIFF
--- a/include/usgscsm/UsgsAstroFrameSensorModel.h
+++ b/include/usgscsm/UsgsAstroFrameSensorModel.h
@@ -38,7 +38,7 @@ class UsgsAstroFrameSensorModel : public csm::RasterGM,
 
   std::string constructStateFromIsd(const std::string &jsonIsd,
                                     csm::WarningList *warnings);
-  
+
   // Apply a rotation and translation to a state string. The effect is
   // to transform the position and orientation of the camera in ECEF
   // coordinates.
@@ -365,6 +365,9 @@ class UsgsAstroFrameSensorModel : public csm::RasterGM,
   std::vector<double> m_iTransS;
   std::vector<double> m_iTransL;
   std::vector<double> m_boresight;
+  std::vector<double> m_lineJitter;
+  std::vector<double> m_sampleJitter;
+  std::vector<double> m_lineTimes;
   double m_majorAxis;
   double m_minorAxis;
   double m_focalLength;

--- a/include/usgscsm/Utilities.h
+++ b/include/usgscsm/Utilities.h
@@ -24,6 +24,19 @@ void computeDistortedFocalPlaneCoordinates(
     const double &startingLine, const double iTransS[], const double iTransL[],
     double &distortedX, double &distortedY);
 
+void removeJitter(
+    const double &line, const double &sample,
+    const std::vector<double> lineJitterCoeffs, const std::vector<double> sampleJitterCoeffs,
+    const std::vector<double> lineTimes,
+    double &dejitteredLine, double &dejitteredSample);
+
+void addJitter(
+    const double &line, const double &sample,
+    const double &tolerance, const int &maxIts,
+    const std::vector<double> lineJitterCoeffs, const std::vector<double> sampleJitterCoeffs,
+    const std::vector<double> lineTimes,
+    double &jitteredLine, double &jitteredSample);
+
 void computePixel(const double &distortedX, const double &distortedY,
                   const double &sampleOrigin, const double &lineOrigin,
                   const double &sampleSumming, const double &lineSumming,

--- a/tests/Fixtures.h
+++ b/tests/Fixtures.h
@@ -131,6 +131,34 @@ class OrbitalFrameSensorModel : public ::testing::Test {
   }
 };
 
+class JitterFrameSensorModel : public ::testing::Test {
+ protected:
+  csm::Isd jitterIsd;
+  csm::Isd isd;
+  std::shared_ptr<csm::RasterGM> jitterModel;
+  std::shared_ptr<csm::RasterGM> model;
+
+  void SetUp() override {
+    csm::Model *genericModel = nullptr;
+
+    UsgsAstroPlugin cameraPlugin;
+
+    isd.setFilename("data/orbitalFramer.img");
+
+    genericModel = cameraPlugin.constructModelFromISD(
+      isd, UsgsAstroFrameSensorModel::_SENSOR_MODEL_NAME);
+    model = std::shared_ptr<csm::RasterGM>(dynamic_cast<csm::RasterGM *>(genericModel));
+    ASSERT_NE(model, nullptr);
+
+    jitterIsd.setFilename("data/jitterFramer.img");
+
+    genericModel = cameraPlugin.constructModelFromISD(
+      jitterIsd, UsgsAstroFrameSensorModel::_SENSOR_MODEL_NAME);
+    jitterModel = std::shared_ptr<csm::RasterGM>(dynamic_cast<csm::RasterGM *>(genericModel));
+    ASSERT_NE(jitterModel, nullptr);
+  }
+};
+
 class FrameIsdTest : public ::testing::Test {
  protected:
   csm::Isd isd;
@@ -255,7 +283,7 @@ class OrbitalLineScanSensorModel : public ::testing::Test {
     model = std::shared_ptr<csm::Model>(cameraPlugin.constructModelFromISD(
       isd, UsgsAstroLsSensorModel::_SENSOR_MODEL_NAME));
     sensorModel = dynamic_cast<UsgsAstroLsSensorModel *>(model.get());
-    
+
     ASSERT_NE(sensorModel, nullptr);
   }
 
@@ -369,7 +397,7 @@ class OrbitalPushFrameSensorModel : public ::testing::Test {
   void SetUp() override {
     isd.setFilename("data/orbitalPushFrame.img");
     UsgsAstroPlugin cameraPlugin;
-    
+
     csm::Model * model = cameraPlugin.constructModelFromISD(
        isd, UsgsAstroPushFrameSensorModel::_SENSOR_MODEL_NAME);
 

--- a/tests/FrameCameraTests.cpp
+++ b/tests/FrameCameraTests.cpp
@@ -190,6 +190,35 @@ TEST_F(OrbitalFrameSensorModel, ImageToProximateImagingLocus) {
 }
 
 // ****************************************************************************
+//   Jitter sensor model tests
+// ****************************************************************************
+
+TEST_F(JitterFrameSensorModel, Center) {
+  // Test jitter is y = -1/256 t^2 + 1/16 t which is 0.25 at t=8
+  csm::ImageCoord imagePt(7.75, 8.25);
+  csm::EcefCoord groundPt = model->imageToGround(imagePt, 0.0);
+
+  csm::ImageCoord jitterImagePt(8.0, 8.0);
+  csm::EcefCoord jitterGroundPt = jitterModel->imageToGround(jitterImagePt, 0.0);
+
+  EXPECT_DOUBLE_EQ(groundPt.x, jitterGroundPt.x);
+  EXPECT_DOUBLE_EQ(groundPt.y, jitterGroundPt.y);
+  EXPECT_DOUBLE_EQ(groundPt.z, jitterGroundPt.z);
+}
+
+TEST_F(JitterFrameSensorModel, Inversion) {
+  for (int line = 0; line <= 16; line++) {
+    for (int sample = 0; sample <= 16; sample++) {
+      csm::ImageCoord imagePt1(line, sample);
+      csm::EcefCoord groundPt = jitterModel->imageToGround(imagePt1, 0.001);
+      csm::ImageCoord imagePt2 = jitterModel->groundToImage(groundPt);
+      EXPECT_NEAR(imagePt1.line, imagePt2.line, 0.001);
+      EXPECT_NEAR(imagePt1.samp, imagePt2.samp, 0.001);
+    }
+  }
+}
+
+// ****************************************************************************
 //   Modified sensor model tests
 // ****************************************************************************
 

--- a/tests/data/jitterFramer.json
+++ b/tests/data/jitterFramer.json
@@ -1,0 +1,97 @@
+{
+  "name_model" : "USGS_ASTRO_FRAME_SENSOR_MODEL",
+  "name_platform" : "TEST_PLATFORM",
+  "name_sensor" : "TEST_SENSOR",
+  "center_ephemeris_time": 1000.0,
+  "detector_sample_summing": 1,
+  "detector_line_summing": 1,
+  "focal2pixel_lines": [0.0, 10.0, 0.0],
+  "focal2pixel_samples": [0.0, 0.0, 10.0],
+  "focal_length_model": {
+    "focal_length": 50
+  },
+  "image_lines": 16,
+  "image_samples": 16,
+  "detector_center" : {
+    "line" : 8.0,
+    "sample" : 8.0
+  },
+  "interpolation_method": "lagrange",
+  "optical_distortion": {
+    "radial": {
+      "coefficients": [0.0, 0.0, 0.0]
+    }
+  },
+  "radii": {
+    "semimajor": 1000,
+    "semiminor": 1000,
+    "unit":"km"
+  },
+  "jitter": {
+    "lineJitterCoefficients": [-0.00390625, 0.0625],
+    "sampleJitterCoefficients": [0.00390625, -0.0625],
+    "lineExposureTimes": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+  },
+  "reference_height": {
+    "maxheight": 1000,
+    "minheight": -1000,
+    "unit": "m"
+  },
+  "instrument_position": {
+    "unit": "km",
+    "positions": [
+      [1050.0, 0.0, 0.0]
+    ],
+    "velocities": [
+      [ 0.0, 0.0, -1.0]
+    ],
+    "ephemeris_times": [
+      50
+    ],
+    "reference_frame": 1
+  },
+  "instrument_pointing": {
+    "quaternions": [
+      [-0.707106781186547, 0.0, -0.707106781186547, 0]
+    ],
+    "angular_velocities": [
+      [0, 0, 0]
+    ],
+    "ephemeris_times": [
+      50
+    ],
+    "reference_frame": 1
+  },
+  "body_rotation": {
+    "quaternions": [
+      [1, 0, 0, 0]
+    ],
+    "ephemeris_times": [
+      50
+    ],
+    "angular_velocities": [
+      [0.0, 0.0, 0.0]
+    ],
+    "reference_frame": 1,
+    "constant_frames": [1, 2, 3],
+    "time_dependent_frames": [4, 5, 6]
+  },
+  "starting_detector_line": 0,
+  "starting_detector_sample": 0,
+  "detector_sample_summing": 1.0,
+  "detector_line_summing": 1.0,
+  "starting_ephemeris_time": 0,
+  "sun_position": {
+    "positions": [
+      [100000.0, 100000.0, 0.0]
+    ],
+    "velocities": [
+      [0.0, 0.0, 0.0]
+    ],
+    "ephemeris_times": [
+      50
+    ],
+    "unit": "m",
+    "reference_frame": 1
+  }
+}


### PR DESCRIPTION
Adds initial rolling shutter frame jitter support to the frame sensor model. An accompanying PR will be in ALE to add this to the ISD for EIS NAC/WAC FC imagery.