### PR TITLE
Added string sanitize function

### DIFF
--- a/include/usgscsm/Utilities.h
+++ b/include/usgscsm/Utilities.h
@@ -171,6 +171,9 @@ std::vector<double> getSensorOrientations(nlohmann::json isd,
 double getWavelength(nlohmann::json isd, csm::WarningList *list = nullptr);
 nlohmann::json stateAsJson(std::string modelState);
 
+// Removes special characters from a string
+void sanitize(std::string &input);
+
 // Apply transforms to orientations and vectors
 void applyRotationToQuatVec(ale::Rotation const& r, std::vector<double> & quaternions);
 void applyRotationTranslationToXyzVec(ale::Rotation const& r, ale::Vec3d const& t,

--- a/src/Utilities.cpp
+++ b/src/Utilities.cpp
@@ -1332,6 +1332,11 @@ json stateAsJson(std::string modelState) {
   return json::parse(modelState.begin() + foundFirst, modelState.begin() + foundLast + 1);
 }
 
+void sanitize(std::string &input){
+  // Remove characters from the string if they are not printable
+  input.erase(std::remove_if(input.begin(), input.end(), [](int c){return !::isprint(c);}), input.end());
+}
+
 // Apply a rotation to a vector of quaternions.
 void applyRotationToQuatVec(ale::Rotation const& r, std::vector<double> & quaternions) {
   int num_quat = quaternions.size();


### PR DESCRIPTION
Related to #400 

To close the issue, we just need to add test data and a unit test!

```
./usgscsm_cam_test --model ESP_037330_1990_REDmos_hijitreged.preTriang.sup --output-model-state ESP_out.json
Detected CSM plugin: UsgsAstroPluginCSM
Number of models for this plugin: 4
Loaded a CSM model of type USGS_ASTRO_LINE_SCANNER_SENSOR_MODEL from model state file ESP_037330_1990_REDmos_hijitreged.preTriang.sup.
Writing model state: ~/gxp/ESP_out.json
```