### PR TITLE
Adds ability to modify GXP .sup Camera State using usgscsm_cam_test

### DIFF
--- a/bin/usgscsm_cam_test.cc
+++ b/bin/usgscsm_cam_test.cc
@@ -3,11 +3,14 @@
 // Functionality:
 //--------------
 //
-// - Load a CSM model in ISD format or model state format, via:
+// - Load a CSM model in ISD format, model state, or GXP .sup file format, via:
 //   --model <model file>
 //
 // - Save the model state if invoked with:
 //   --output-model-state <model state .json file>
+//
+// - Modify GXP .sup file's model state with inputed model:
+//   --modify-sup-file <GXP .sup file>
 //
 // - Test projecting rays from the camera to ground, then back,
 //   and compare with the original pixel values.

--- a/bin/usgscsm_cam_test.cc
+++ b/bin/usgscsm_cam_test.cc
@@ -22,6 +22,7 @@
 
 struct Options {
   std::string model;              // the .json file in isd or model state format
+  std::string modify_sup_file;    // the .sup file needing a modified model state
   std::string output_model_state; // the output model state in .json format
   int sample_rate;
   double subpixel_offset, height_above_datum, desired_precision;
@@ -91,6 +92,7 @@ bool parseOptions(int argc, char **argv, Options & opt) {
     parsed_options["desired-precision"] = "0.001"; // set default value
 
   // Collect all other option values. If not set, the values will default to 0.
+  opt.modify_sup_file    = parsed_options["modify-sup-file"];
   opt.output_model_state = parsed_options["output-model-state"];
   opt.sample_rate        = sample_rate_double;
   opt.subpixel_offset    = atof(parsed_options["subpixel-offset"].c_str());
@@ -142,8 +144,6 @@ bool loadCsmCameraModel(std::string const& model_file,
   if (!readFileInString(model_file, model_state))
     return false;
 
-  // Remove special characters from string
-  sanitize(model_state);
 
   // Check if loading the model worked
   bool success = false;
@@ -202,6 +202,31 @@ bool loadCsmCameraModel(std::string const& model_file,
   return true;
 }
 
+bool updateSupModel(std::string& sup_string, std::string model) {
+  // grab the state JSON out of the original sup file to determine length of string to replace
+  std::string sup_state = stateAsJson(sup_string).dump().c_str();
+
+  // add back in the BEL characters in json state for GXP to read .sup file
+  std::replace(model.begin(), model.end(), '\n', '\a');
+
+  // update the .sup file SENSOR_STATE_LENGTH with new state length
+  std::string sensor_length = "SENSOR_STATE_LENGTH ";
+  size_t start_len_pos = sup_string.find(sensor_length) + sensor_length.length();
+  size_t end_len_pos = sup_string.find("SENSOR_STATE ") - 1;
+  sup_string.replace(start_len_pos, end_len_pos - start_len_pos, std::to_string(model.length()));
+
+  //replace the camera state in .sup file at the state model name which start with "USGS_ASTRO"
+  size_t start_pos = sup_string.find("USGS_ASTRO");
+  std::size_t end_pos = sup_string.find_last_of("}");
+
+  if(start_pos == std::string::npos)
+    return false;
+
+  sup_string.replace(start_pos, (end_pos - start_pos) + 1, model);
+  return true;
+}
+
+
 int main(int argc, char **argv) {
 
   Options opt;
@@ -220,6 +245,19 @@ int main(int argc, char **argv) {
     std::ofstream ofs(opt.output_model_state.c_str());
     ofs << model->getModelState() << "\n";
     ofs.close();
+  }
+
+  if (opt.modify_sup_file != "") {
+    std::string sup_string;
+    readFileInString(opt.modify_sup_file, sup_string);
+
+    if (!updateSupModel(sup_string, model->getModelState()))
+      return 1;
+
+    std::cout << "Updating model state for sup file: " << opt.modify_sup_file << "\n";
+    std::ofstream ofs_sup(opt.modify_sup_file.c_str());
+    ofs_sup << sup_string << "\n";
+    ofs_sup.close();
   }
 
   if (opt.sample_rate > 0) {

--- a/docs/source/tools/usgscsm_cam_test.rst
+++ b/docs/source/tools/usgscsm_cam_test.rst
@@ -3,8 +3,8 @@ usgscsm_cam_test
 
 This program is shipped with the USGSCSM library in the ``bin`` directory.
 It can be used for performing several operations involving CSM camera
-models, such as loading a camera model, whether in the original ISD format
-or its model state representation, exporting the model state, computing
+models, such as loading a camera model, whether in the original ISD format,
+model state representation, or GXP .sup file exporting the model state, computing
 projections from pixels in the camera to the ground and back, and
 then verifying that the original pixels are obtained.
 
@@ -17,31 +17,39 @@ Example (perform per-pixel operations)::
     usgscsm_cam_test --model camera.json --sample-rate 100 \
        --height-above-datum 320.3 --subpixel-offset 0.57
 
+Example (modify a GXP .sup with new model state)::
+
+   usgscsm_cam_test --model camera.json --modify-sup-file gxp_file.sup
+
 Command line options
 ~~~~~~~~~~~~~~~~~~~~
 
 --model <string (default: "")>
-    Input CSM model (in ISD or model state format).
+    Input CSM model (in ISD, model state, or GXP .sup file format).
 
 --output-model-state <string (default: "")>
     If specified, save the model state to this file.
 
 --sample-rate <integer (default: 0)>
-    If positive, select pixels in the camera at the intersection of 
-    every one out of this many rows and columns, and perform projections 
+    If positive, select pixels in the camera at the intersection of
+    every one out of this many rows and columns, and perform projections
     to the ground and back.
-    
---subpixel-offset <double (default: 0.0)> 
-    Add this value to every pixel row and column to 
+
+--subpixel-offset <double (default: 0.0)>
+    Add this value to every pixel row and column to
     be sampled.
 
 --height-above-datum <double (default: 0.0)>
-    Let the ground be obtained from the datum for this camera by 
+    Let the ground be obtained from the datum for this camera by
     adding to its radii this value (the units are meters).
 
 --desired-precision <double (default: 0.001)>
     Use this value for operations (ground-to-image and image-to-ground)
     which need a precision value. Measured in pixels.
+
+--modify-sup-file (default: "")>
+    Input GXP .sup file to be modified by inputted CSM model. This will override
+    the existing .sup file's SENSOR_STATE.
 
 --help <no value>
     Print the usage message.

--- a/src/Utilities.cpp
+++ b/src/Utilities.cpp
@@ -1325,6 +1325,9 @@ double getWavelength(json isd, csm::WarningList *list) {
 }
 
 json stateAsJson(std::string modelState) {
+  // Remove special characters from string
+  sanitize(modelState);
+
   std::size_t foundFirst = modelState.find_first_of("{");
   std::size_t foundLast = modelState.find_last_of("}");
 
@@ -1336,7 +1339,7 @@ json stateAsJson(std::string modelState) {
 
 void sanitize(std::string &input){
   // Remove characters from the string if they are not printable
-  input.erase(std::remove_if(input.begin(), input.end(), [](int c){return !::isprint(c);}), input.end());
+  std::replace_if(input.begin(), input.end(), [](int c){return !::isprint(c);}, '\n');
 }
 
 // Read a file's content in a single string

--- a/src/Utilities.cpp
+++ b/src/Utilities.cpp
@@ -1338,7 +1338,7 @@ json stateAsJson(std::string modelState) {
 }
 
 void sanitize(std::string &input){
-  // Remove characters from the string if they are not printable
+  // Replaces characters from the string that are not printable with newlines
   std::replace_if(input.begin(), input.end(), [](int c){return !::isprint(c);}, '\n');
 }
 

--- a/tests/UtilitiesTests.cpp
+++ b/tests/UtilitiesTests.cpp
@@ -495,5 +495,5 @@ TEST(UtilitiesTests, fileReaderTest) {
 TEST(UtilitiesTests, sanitizeTest) {
   std::string input = "\nHello World\007";
   sanitize(input);
-  EXPECT_STREQ(input.c_str(), "Hello World");
+  EXPECT_STREQ(input.c_str(), "\nHello World\n");
 }


### PR DESCRIPTION
Adds optional parameter for running `usgscsm_cam_test` with a .sup file to modify camera state within .sup file with new model inputted with `--model` parameter.

Updates documentation and tests associated with usgscsm_cam_test.