### PR TITLE
Change main license to CC-1.0

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,11 +1,48 @@
-Copyright  © 2017-2022 BAE Systems Information and Electronic Systems Integration Inc.
+Unless otherwise noted, this project is in the public domain in the
+United States.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+It contains materials that originally came from the United States
+Geological Survey, an agency of the United States Department of
+Interior.  For more information on their copyright policies, see
+https://www.usgs.gov/information-policies-and-instructions/copyrights-and-credits
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+Several files in this project were originally developed and are copyrighted by
+BAE Systems Information and Electronic Systems Integration Inc. They are licensed
+under the BDS 3 clause license and have comments identifying this at the top.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+It also contains materials from contributors that have waived their
+copyright interest to the public domain.
 
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+Additionally, the authors waive copyright and related rights in the
+work worldwide through the CC0 1.0 Universal public domain dedication.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+CC0 1.0 Universal Summary
+-------------------------
+
+This is a human-readable summary of the [Legal Code (read the full
+text)](https://creativecommons.org/publicdomain/zero/1.0/legalcode).
+
+
+### No Copyright
+
+The authors have associated their contributions to the ISIS project
+with this deed, and have dedicated the work to the public domain
+by waiving all of their rights to the work worldwide under copyright
+law, including all related and neighboring rights, to the extent
+allowed by law.
+
+You can copy, modify, distribute and perform the work, even for
+commercial purposes, all without asking permission.
+
+
+### Other Information
+
+In no way are the patent or trademark rights of any person affected
+by CC0, nor are the rights that other persons may have in the work
+or in how the work is used, such as publicity or privacy rights.
+
+Unless expressly stated otherwise, the authors who have associated
+the ISIS project with this deed make no warranties about the work,
+and disclaim liability for all uses of the work, to the fullest
+extent permitted by applicable law. When using or citing the work,
+you should not imply endorsement by the authors.

--- a/code.json
+++ b/code.json
@@ -10,7 +10,7 @@
       "usageType": "openSource",
       "licenses": [
         {
-          "name": "BSD 3-Clause",
+          "name": "Public Domain, CC-1.0",
           "URL": "https://github.com/USGS-Astrogeology/usgscsm/blob/dev/LICENSE.md"
         }
       ]
@@ -41,7 +41,7 @@
     },
 
     "date": {
-      "metadataLastUpdated": "2022-04-15"
+      "metadataLastUpdated": "2022-07-06"
     }
   }
 ]

--- a/include/usgscsm/UsgsAstroLsSensorModel.h
+++ b/include/usgscsm/UsgsAstroLsSensorModel.h
@@ -1,29 +1,26 @@
-//----------------------------------------------------------------------------
-//
-//                                UNCLASSIFIED
-//
-// Copyright © 1989-2017 BAE Systems Information and Electronic Systems
-// Integration Inc.
-//                            ALL RIGHTS RESERVED
-// Use of this software product is governed by the terms of a license
-// agreement. The license agreement is found in the installation directory.
-//
-//             For support, please visit http://www.baesystems.com/gxp
-//
-//  Description:
-//    The Astro Line Scanner sensor model implements the CSM 3.0.3 API.
-//    Since it supports a sensor used on non-Earth bodies (Moon, Mars), the
-//    ellipsoid is made settable based on the support data.  This ellipsoid
-//    is reported using the methods in the SettableEllipsoid class from which
-//    this model inherits.
-//
-//  Revision History:
-//  Date        Name         Description
-//  ----------- ------------ -----------------------------------------------
-//  13-Nov-2015 BAE Systems  Initial Implementation
-//  16-OCT-2017 BAE Systems  Update for CSM 3.0.3
-//
-//-----------------------------------------------------------------------------
+/** Copyright  © 2017-2022 BAE Systems Information and Electronic Systems Integration Inc.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted
+provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions
+and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of
+conditions and the following disclaimer in the documentation and/or other materials provided
+with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to
+endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. **/
 
 #ifndef INCLUDE_USGSCSM_USGSASTROLSSENSORMODEL_H_
 #define INCLUDE_USGSCSM_USGSASTROLSSENSORMODEL_H_
@@ -159,7 +156,7 @@ class UsgsAstroLsSensorModel : public csm::RasterGM,
   // coordinates.
   static void applyTransformToState(ale::Rotation const& r, ale::Vec3d const& t,
                                     std::string& stateString);
-  
+
   // Set the sensor model based on the input state data
   void set(const std::string& state_data);
 
@@ -972,23 +969,23 @@ class UsgsAstroLsSensorModel : public csm::RasterGM,
   // for iterative rigorous calculations.
   void computeProjectiveApproximation(const csm::EcefCoord& gp,
                                       csm::ImageCoord& ip) const;
-  
+
   // Create the projective approximation to be used at each ground point
   void createProjectiveApproximation();
-  
+
   // A function whose value will be 0 when the line a given ground
   // point projects into is found. The obtained line will be
   // approxPt.line + t.
   double calcDetectorLineErr(double t, csm::ImageCoord const& approxPt,
                              const csm::EcefCoord& groundPt,
                              const std::vector<double>& adj) const;
-  
+
   csm::NoCorrelationModel _no_corr_model;  // A way to report no correlation
                                            // between images is supported
   std::vector<double> _no_adjustment;  // A vector of zeros indicating no internal adjustment
 
   // Store here the projective approximation of the sensor model
-  std::vector<double> m_projTransCoeffs; 
+  std::vector<double> m_projTransCoeffs;
 
   // Flag indicating if an initial approximation is used
   bool m_useApproxInitTrans;

--- a/include/usgscsm/UsgsAstroPlugin.h
+++ b/include/usgscsm/UsgsAstroPlugin.h
@@ -1,3 +1,27 @@
+/** Copyright  © 2017-2022 BAE Systems Information and Electronic Systems Integration Inc.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted
+provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions
+and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of
+conditions and the following disclaimer in the documentation and/or other materials provided
+with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to
+endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. **/
+
 #ifndef INCLUDE_USGSCSM_USGSASTROPLUGIN_H_
 #define INCLUDE_USGSCSM_USGSASTROPLUGIN_H_
 

--- a/include/usgscsm/UsgsAstroPushFrameSensorModel.h
+++ b/include/usgscsm/UsgsAstroPushFrameSensorModel.h
@@ -1,3 +1,27 @@
+/** Copyright  © 2017-2022 BAE Systems Information and Electronic Systems Integration Inc.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted
+provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions
+and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of
+conditions and the following disclaimer in the documentation and/or other materials provided
+with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to
+endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. **/
+
 #ifndef INCLUDE_USGSCSM_USGSASTROPUSHFRAMESENSORMODEL_H_
 #define INCLUDE_USGSCSM_USGSASTROPUSHFRAMESENSORMODEL_H_
 

--- a/src/UsgsAstroPlugin.cpp
+++ b/src/UsgsAstroPlugin.cpp
@@ -1,3 +1,27 @@
+/** Copyright  © 2017-2022 BAE Systems Information and Electronic Systems Integration Inc.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted
+provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions
+and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of
+conditions and the following disclaimer in the documentation and/or other materials provided
+with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to
+endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. **/
+
 #include "UsgsAstroPlugin.h"
 
 #include "UsgsAstroFrameSensorModel.h"

--- a/src/UsgsAstroPushFrameSensorModel.cpp
+++ b/src/UsgsAstroPushFrameSensorModel.cpp
@@ -1,3 +1,27 @@
+/** Copyright  © 2017-2022 BAE Systems Information and Electronic Systems Integration Inc.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted
+provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions
+and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of
+conditions and the following disclaimer in the documentation and/or other materials provided
+with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to
+endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. **/
+
 #include "UsgsAstroPushFrameSensorModel.h"
 #include "Distortion.h"
 #include "Utilities.h"
@@ -464,7 +488,7 @@ std::string UsgsAstroPushFrameSensorModel::getModelState() const {
       "m_nReducedLines: {} ",
       state["m_numLinesOverlap"].dump(), state["m_reducedFrameletHeight"].dump(),
       state["m_nReducedLines"].dump());
-  
+
   std::string stateString = getModelName() + "\n" + state.dump(2);
   return stateString;
 }
@@ -752,7 +776,7 @@ csm::ImageCoord UsgsAstroPushFrameSensorModel::groundToImage(
 
   // Adjust for the fact that several lines were removed at the framelet top and bottom
   imagePt.line -= m_numLinesOverlap/2;
-  
+
   imagePt.samp = (detectorSample + m_detectorSampleOrigin - m_startingDetectorSample)
                / m_detectorSampleSumming;
 
@@ -1238,7 +1262,7 @@ std::string UsgsAstroPushFrameSensorModel::getReferenceDateAndTime() const {
   double relativeTime =
       UsgsAstroPushFrameSensorModel::getImageTime(referencePointImage);
   time_t ephemTime = m_centerEphemerisTime + relativeTime;
-  
+
   return ephemTimeToCalendarTime(ephemTime);
 }
 
@@ -1743,12 +1767,12 @@ void UsgsAstroPushFrameSensorModel::losToEcf(
   double frameletLine = std::fmod(line, summedFrameletHeight);
   if (m_frameletsFlipped) {
     // TODO: Below may need to subtract 1. Need a testcase where this happens.
-    frameletLine = summedFrameletHeight - frameletLine; 
+    frameletLine = summedFrameletHeight - frameletLine;
   }
 
   // Adjust for the fact that several lines were removed at the framelet top and bottom
   frameletLine += m_numLinesOverlap/2;
-  
+
   // Compute distorted image coordinates in mm (sample, line on image (pixels)
   // -> focal plane
   double distortedFocalPlaneX, distortedFocalPlaneY;
@@ -2433,7 +2457,7 @@ std::string UsgsAstroPushFrameSensorModel::constructStateFromIsd(
     - state["m_numLinesOverlap"].get<int>();
   int numFramelets = state["m_nLines"].get<int>() / state["m_frameletHeight"].get<int>();
   state["m_nReducedLines"] = numFramelets * state["m_reducedframeletHeight"].get<int>();
-  
+
   if (!parsingWarnings->empty()) {
     if (warnings) {
       warnings->insert(warnings->end(), parsingWarnings->begin(),


### PR DESCRIPTION
This changes the main license back to CC-1.0 from BDS-3. Only the code originally from BAE or based on the code from BAE has had to BDS-3 Licence added to the top of it.

Fixes #401 