### PR TITLE
Checked for set adjustments in getAdjSensorPosVel when determining if velocity is needed

### DIFF
--- a/src/UsgsAstroLsSensorModel.cpp
+++ b/src/UsgsAstroLsSensorModel.cpp
@@ -1946,7 +1946,7 @@ void UsgsAstroLsSensorModel::getAdjSensorPosVel(const double& time,
   if (!calc_vel) {
     bool has_adj = false;
     for (size_t it = 0; it < adj.size(); it++) {
-      if (adj[it] != 0) has_adj = true;
+      if (getValue(it, adj) != 0) has_adj = true;
     }
     if (!has_adj) {
       xc = sensPosNom[0];


### PR DESCRIPTION
The change in #385 only checks for adjustments being passed into the function, it doesn't check for adjustments that already exist in the model.

This resulted in the velocity not being computed when adjustments were set in the model and then it cannot compute the in-track.cross-track coordinate system properly.