### PR TITLE
Fix compile-time conflict due to ambiguous Plugin.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ set_target_properties(usgscsm PROPERTIES
 
 set(USGSCSM_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include/usgscsm"
                          "${CMAKE_CURRENT_SOURCE_DIR}/include"
+                         "${CMAKE_CURRENT_SOURCE_DIR}"
                          "${EIGEN3_INCLUDE_DIR}")
 
 # These will be copied upon installation to ${CMAKE_INSTALL_INCLUDEDIR}/include

--- a/include/usgscsm/UsgsAstroPlugin.h
+++ b/include/usgscsm/UsgsAstroPlugin.h
@@ -26,11 +26,11 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
 #define INCLUDE_USGSCSM_USGSASTROPLUGIN_H_
 
 #include <string>
-#include<map>
-#include<memory>
+#include <map>
+#include <memory>
 
-#include <Plugin.h>
-#include <Version.h>
+#include <csm/Plugin.h>
+#include <csm/Version.h>
 
 #include <nlohmann/json.hpp>
 #include "spdlog/spdlog.h"

--- a/src/UsgsAstroFrameSensorModel.cpp
+++ b/src/UsgsAstroFrameSensorModel.cpp
@@ -6,8 +6,8 @@
 
 #include <nlohmann/json.hpp>
 
-#include <Error.h>
-#include <Version.h>
+#include <csm/Error.h>
+#include <csm/Version.h>
 
 #include "ale/Util.h"
 

--- a/src/UsgsAstroPlugin.cpp
+++ b/src/UsgsAstroPlugin.cpp
@@ -34,11 +34,12 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
 #include <fstream>
 #include <string>
 
-#include <Error.h>
-#include <Plugin.h>
-#include <Version.h>
-#include <Warning.h>
-#include <csm.h>
+#include <csm/Error.h>
+#include <csm/Plugin.h>
+#include <csm/Version.h>
+#include <csm/Warning.h>
+#include <csm/csm.h>
+
 #include <math.h>
 
 #include "spdlog/sinks/basic_file_sink.h"


### PR DESCRIPTION
Both CSM and ISIS have a header file named Plugin.h, which can result in a compile-time error for code which includes both. This proposes a fix by disambiguating some csm headers by replacing "Plugin.h" with "csm/Plugin.h", etc. 