### PR TITLE
Apply transform to reference point in PushFrameSensor and spellcheck

### DIFF
--- a/src/UsgsAstroPushFrameSensorModel.cpp
+++ b/src/UsgsAstroPushFrameSensorModel.cpp
@@ -518,6 +518,11 @@ void UsgsAstroPushFrameSensorModel::applyTransformToState(ale::Rotation const& r
   applyRotationTranslationToXyzVec(r, zero_t, velocities);
   j["m_velocities"] = velocities;
 
+  // Apply the transform to the reference point
+  std::vector<double> refPt = j["m_referencePointXyz"];
+  applyRotationTranslationToXyzVec(r, t, refPt);
+  j["m_referencePointXyz"] = refPt;
+
   // We do not change the Sun position or velocity. The idea is that
   // the Sun is so far, that minor camera adjustments won't affect
   // where the Sun is.

--- a/src/Utilities.cpp
+++ b/src/Utilities.cpp
@@ -34,7 +34,7 @@ void calculateRotationMatrixFromEuler(double euler[], double rotationMatrix[]) {
   rotationMatrix[8] = cos_a * cos_b;
 }
 
-// uses a quaternion to calclate a rotation matrix.
+// uses a quaternion to calculate a rotation matrix.
 // in - q[4]
 // out - rotationMatrix[9]
 void calculateRotationMatrixFromQuaternions(double q[4],


### PR DESCRIPTION
Somehow the PushFrame sensor model is missing a minor bit of logic present for the other models (Frame, Linescan SAR). When a transform is applied to the cameras, the ground reference point should move accordingly, as the camera centers (and orientations and velocities) move. 

Likely this does not matter much, if at all, as the reference point is only used to set up m_gsd and other such things when the model state is created, and it is not used later during actual image-to-ground and ground-to-image operations, but likely it is best to keep it consistent with the rest of the model. 