### PR TITLE
Initialize m_startingDetectorLine

### DIFF
--- a/src/UsgsAstroLsSensorModel.cpp
+++ b/src/UsgsAstroLsSensorModel.cpp
@@ -527,6 +527,7 @@ void UsgsAstroLsSensorModel::reset() {
   m_detectorSampleSumming = 1.0;  // 15
   m_detectorLineSumming = 1.0;
   m_startingDetectorSample = 1.0;  // 16
+  m_startingDetectorLine   = 1.0;
   m_ikCode = -85600;               // 17
   m_focalLength = 350.0;           // 18
   m_zDirection = 1.0;              // 19


### PR DESCRIPTION
This is a housekeeping fix. The variable m_startingDetectorLine was not being initialized during the reset() call. Normally that's not an issue if the linescan model is being read from an isd, but may be an issue if it is created from scratch. Now this is also going to be consistent with  m_startingDetectorSample (line right above).